### PR TITLE
Fix Notify Requires

### DIFF
--- a/lua/gitlab/comment.lua
+++ b/lua/gitlab/comment.lua
@@ -1,5 +1,6 @@
 local Menu               = require("nui.menu")
 local NuiTree            = require("nui.tree")
+local notify             = require("notify")
 local Job                = require("plenary.job")
 local state              = require("gitlab.state")
 local u                  = require("gitlab.utils")
@@ -93,7 +94,7 @@ M.delete_comment         = function()
           on_stdout = function(_, line)
             vim.schedule(function()
               if line ~= nil and line ~= "" then
-                require("notify")(line, "info")
+                notify(line, "info")
                 state.tree:remove_node("-" .. note_id)
                 local discussion_node = state.tree:get_node("-" .. discussion_id)
                 if not discussion_node:has_children() then
@@ -155,7 +156,7 @@ M.send_edits   = function(text)
     on_stdout = function(_, line)
       local note = vim.json.decode(line)
       if note == nil then
-        require("notify")("There was an issue editing the note", "error")
+        notify("There was an issue editing the note", "error")
         return
       end
 
@@ -177,7 +178,7 @@ M.send_edits   = function(text)
         state.tree:render()
         local buf = vim.api.nvim_get_current_buf()
         u.darken_metadata(buf, '')
-        require("notify")("Edited comment!")
+        notify("Edited comment!")
       end)
     end,
     on_stderr = u.print_error

--- a/lua/gitlab/discussions.lua
+++ b/lua/gitlab/discussions.lua
@@ -1,5 +1,6 @@
 local u            = require("gitlab.utils")
 local NuiTree      = require("nui.tree")
+local notify       = require("notify")
 local state        = require("gitlab.state")
 local Job          = require("plenary.job")
 local Popup        = require("nui.popup")
@@ -27,7 +28,7 @@ M.send_reply       = function(text)
     on_stdout = function(_, line)
       local note = vim.json.decode(line)
       if note == nil then
-        require("notify")("There was an issue creating the note", "error")
+        notify("There was an issue creating the note", "error")
         return
       end
 
@@ -39,7 +40,7 @@ M.send_reply       = function(text)
         state.tree:render()
         local buf = vim.api.nvim_get_current_buf()
         u.darken_metadata(buf, '')
-        require("notify")("Sent reply!")
+        notify("Sent reply!")
       end)
     end,
     on_stderr = u.print_error
@@ -62,7 +63,7 @@ M.list_discussions = function()
         vim.api.nvim_buf_set_option(buf, 'filetype', 'markdown')
         vim.api.nvim_set_current_buf(buf)
         if discussions == nil then
-          require("notify")("No discussions found for this MR", "warn")
+          notify("No discussions found for this MR", "warn")
         else
           local allDiscussions = {}
           for i, discussion in ipairs(discussions) do

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -60,16 +60,16 @@ M.setup = function(args)
         table.insert(projectData, line)
       end,
       -- on_stderr = u.print_error,
-      -- on_exit = function()
-      --   if projectData[1] ~= nil then
-      --     local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-      --     if parsed_ok ~= true then
-      --       require("notify")("Failed calling setup. Could not get project data.", "error")
-      --     else
-      --       state.INFO = data
-      --     end
-      --   end
-      -- end,
+      on_exit = function()
+        if projectData[1] ~= nil then
+          local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+          if parsed_ok ~= true then
+            require("notify")("Failed calling setup. Could not get project data.", "error")
+          else
+            state.INFO = data
+          end
+        end
+      end,
     }):start()
   end
 

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -52,28 +52,26 @@ M.setup = function(args)
     state.BASE_BRANCH = args.base_branch
   end
 
-  if u.is_gitlab_repo() then
-    Job:new({
-      command = state.BIN,
-      args = { "info", state.PROJECT_ID },
-      on_stdout = function(_, line)
-        table.insert(projectData, line)
-      end,
-      on_stderr = u.print_error,
-      on_exit = function()
-        -- vim.schedule(function()
-        --   if projectData[1] ~= nil then
-        --     local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-        --     if parsed_ok ~= true then
-        --       require("notify")("Failed calling setup. Could not get project data.", "error")
-        --     else
-        --       state.INFO = data
-        --     end
-        --   end
-        -- end)
-      end,
-    }):start()
-  end
+  -- if u.is_gitlab_repo() then
+  --   Job:new({
+  --     command = state.BIN,
+  --     args = { "info", state.PROJECT_ID },
+  --     on_stdout = function(_, line)
+  --       table.insert(projectData, line)
+  --     end,
+  --     on_stderr = u.print_error,
+  --     on_exit = function()
+  --       if projectData[1] ~= nil then
+  --         local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+  --         if parsed_ok ~= true then
+  --           require("notify")("Failed calling setup. Could not get project data.", "error")
+  --         else
+  --           state.INFO = data
+  --         end
+  --       end
+  --     end,
+  --   }):start()
+  -- end
 
   keymaps.set_keymap_keys(args.keymaps)
 end

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -53,24 +53,24 @@ M.setup = function(args)
   end
 
   -- if u.is_gitlab_repo() then
-  --   Job:new({
-  --     command = state.BIN,
-  --     args = { "info", state.PROJECT_ID },
-  --     on_stdout = function(_, line)
-  --       table.insert(projectData, line)
-  --     end,
-  --     on_stderr = u.print_error,
-  --     on_exit = function()
-  --       if projectData[1] ~= nil then
-  --         local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-  --         if parsed_ok ~= true then
-  --           require("notify")("Failed calling setup. Could not get project data.", "error")
-  --         else
-  --           state.INFO = data
-  --         end
-  --       end
-  --     end,
-  --   }):start()
+  Job:new({
+    command = state.BIN,
+    args = { "info", state.PROJECT_ID },
+    on_stdout = function(_, line)
+      table.insert(projectData, line)
+    end,
+    on_stderr = u.print_error,
+    on_exit = function()
+      if projectData[1] ~= nil then
+        local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+        if parsed_ok ~= true then
+          require("notify")("Failed calling setup. Could not get project data.", "error")
+        else
+          state.INFO = data
+        end
+      end
+    end,
+  }):start()
   -- end
 
   keymaps.set_keymap_keys(args.keymaps)

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -52,30 +52,28 @@ M.setup = function(args)
     state.BASE_BRANCH = args.base_branch
   end
 
-  vim.schedule(function()
-    if u.is_gitlab_repo() then
-      Job:new({
-        command = state.BIN,
-        args = { "info", state.PROJECT_ID },
-        on_stdout = function(_, line)
-          table.insert(projectData, line)
-        end,
-        on_stderr = u.print_error,
-        on_exit = function()
-          vim.schedule(function()
-            if projectData[1] ~= nil then
-              local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-              if parsed_ok ~= true then
-                require("notify")("Failed calling setup. Could not get project data.", "error")
-              else
-                state.INFO = data
-              end
-            end
-          end)
-        end,
-      }):start()
-    end
-  end)
+  if u.is_gitlab_repo() then
+    Job:new({
+      command = state.BIN,
+      args = { "info", state.PROJECT_ID },
+      on_stdout = function(_, line)
+        table.insert(projectData, line)
+      end,
+      on_stderr = u.print_error,
+      on_exit = function()
+        -- vim.schedule(function()
+        --   if projectData[1] ~= nil then
+        --     local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+        --     if parsed_ok ~= true then
+        --       require("notify")("Failed calling setup. Could not get project data.", "error")
+        --     else
+        --       state.INFO = data
+        --     end
+        --   end
+        -- end)
+      end,
+    }):start()
+  end
 
   keymaps.set_keymap_keys(args.keymaps)
 end

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -32,16 +32,17 @@ M.setup = function(args)
 
   state.BIN_PATH = parent_dir
   state.BIN = parent_dir .. "/bin"
-
-  local binExists = io.open(state.BIN, "r")
-  if not binExists or args.dev == true then
-    local command = string.format("cd %s && make", state.BIN_PATH)
-    local installCode = os.execute(command .. "> /dev/null")
-    if installCode ~= 0 then
-      require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
-      return
+  vim.schedule(function()
+    local binExists = io.open(state.BIN, "r")
+    if not binExists or args.dev == true then
+      local command = string.format("cd %s && make", state.BIN_PATH)
+      local installCode = os.execute(command .. "> /dev/null")
+      if installCode ~= 0 then
+        require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
+        return
+      end
     end
-  end
+  end)
 
   if args.project_id == nil then
     error("No project ID provided!")

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -27,55 +27,55 @@ local function current_file_path()
 end
 
 M.setup = function(args)
-  local file_path = current_file_path()
-  local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h")
-
-  state.BIN_PATH = parent_dir
-  state.BIN = parent_dir .. "/bin"
-
-  local binExists = io.open(state.BIN, "r")
-  if not binExists or args.dev == true then
-    local command = string.format("cd %s && make", state.BIN_PATH)
-    local installCode = os.execute(command .. "> /dev/null")
-    if installCode ~= 0 then
-      require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
-      return
-    end
-  end
-
-  if args.project_id == nil then
-    error("No project ID provided!")
-  end
-  state.PROJECT_ID = args.project_id
-
-  if args.base_branch ~= nil then
-    state.BASE_BRANCH = args.base_branch
-  end
-
-  if u.is_gitlab_repo() then
-    Job:new({
-      command = state.BIN,
-      args = { "info", state.PROJECT_ID },
-      on_stdout = function(_, line)
-        table.insert(projectData, line)
-      end,
-      on_stderr = u.print_error,
-      on_exit = function()
-        vim.schedule(function()
-          if projectData[1] ~= nil then
-            local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-            if parsed_ok ~= true then
-              require("notify")("Failed calling setup. Could not get project data.", "error")
-            else
-              state.INFO = data
-            end
-          end
-        end)
-      end,
-    }):start()
-  end
-
-  keymaps.set_keymap_keys(args.keymaps)
+  -- local file_path = current_file_path()
+  -- local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h")
+  --
+  -- state.BIN_PATH = parent_dir
+  -- state.BIN = parent_dir .. "/bin"
+  --
+  -- local binExists = io.open(state.BIN, "r")
+  -- if not binExists or args.dev == true then
+  --   local command = string.format("cd %s && make", state.BIN_PATH)
+  --   local installCode = os.execute(command .. "> /dev/null")
+  --   if installCode ~= 0 then
+  --     require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
+  --     return
+  --   end
+  -- end
+  --
+  -- if args.project_id == nil then
+  --   error("No project ID provided!")
+  -- end
+  -- state.PROJECT_ID = args.project_id
+  --
+  -- if args.base_branch ~= nil then
+  --   state.BASE_BRANCH = args.base_branch
+  -- end
+  --
+  -- if u.is_gitlab_repo() then
+  --   Job:new({
+  --     command = state.BIN,
+  --     args = { "info", state.PROJECT_ID },
+  --     on_stdout = function(_, line)
+  --       table.insert(projectData, line)
+  --     end,
+  --     on_stderr = u.print_error,
+  --     on_exit = function()
+  --       vim.schedule(function()
+  --         if projectData[1] ~= nil then
+  --           local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+  --           if parsed_ok ~= true then
+  --             require("notify")("Failed calling setup. Could not get project data.", "error")
+  --           else
+  --             state.INFO = data
+  --           end
+  --         end
+  --       end)
+  --     end,
+  --   }):start()
+  -- end
+  --
+  -- keymaps.set_keymap_keys(args.keymaps)
 end
 
 return M

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -59,7 +59,7 @@ M.setup = function(args)
       -- on_stdout = function(_, line)
       --   table.insert(projectData, line)
       -- end,
-      -- on_stderr = u.print_error,
+      on_stderr = u.print_error,
       -- on_exit = function()
       --   if projectData[1] ~= nil then
       --     local parsed_ok, data = pcall(vim.json.decode, projectData[1])

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -1,5 +1,6 @@
 local Job          = require("plenary.job")
 local state        = require("gitlab.state")
+local notify       = require("notify")
 local discussions  = require("gitlab.discussions")
 local summary      = require("gitlab.summary")
 local keymaps      = require("gitlab.keymaps")
@@ -38,7 +39,7 @@ M.setup = function(args)
     local command = string.format("cd %s && make", state.BIN_PATH)
     local installCode = os.execute(command .. "> /dev/null")
     if installCode ~= 0 then
-      require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
+      notify("Could not install gitlab.nvim! Do you have Go installed?", "error")
       return
     end
   end
@@ -59,12 +60,12 @@ M.setup = function(args)
       on_stdout = function(_, line)
         table.insert(projectData, line)
       end,
-      -- on_stderr = u.print_error,
+      on_stderr = u.print_error,
       on_exit = function()
         if projectData[1] ~= nil then
           local parsed_ok, data = pcall(vim.json.decode, projectData[1])
           if parsed_ok ~= true then
-            require("notify")("Failed calling setup. Could not get project data.", "error")
+            notify("Failed calling setup. Could not get project data.", "error")
           else
             state.INFO = data
           end

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -32,17 +32,16 @@ M.setup = function(args)
 
   state.BIN_PATH = parent_dir
   state.BIN = parent_dir .. "/bin"
-  vim.schedule(function()
-    local binExists = io.open(state.BIN, "r")
-    if not binExists or args.dev == true then
-      local command = string.format("cd %s && make", state.BIN_PATH)
-      local installCode = os.execute(command .. "> /dev/null")
-      if installCode ~= 0 then
-        require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
-        return
-      end
+
+  local binExists = io.open(state.BIN, "r")
+  if not binExists or args.dev == true then
+    local command = string.format("cd %s && make", state.BIN_PATH)
+    local installCode = os.execute(command .. "> /dev/null")
+    if installCode ~= 0 then
+      require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
+      return
     end
-  end)
+  end
 
   if args.project_id == nil then
     error("No project ID provided!")
@@ -62,14 +61,16 @@ M.setup = function(args)
       end,
       on_stderr = u.print_error,
       on_exit = function()
-        if projectData[1] ~= nil then
-          local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-          if parsed_ok ~= true then
-            require("notify")("Failed calling setup. Could not get project data.", "error")
-          else
-            state.INFO = data
+        vim.schedule(function()
+          if projectData[1] ~= nil then
+            local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+            if parsed_ok ~= true then
+              require("notify")("Failed calling setup. Could not get project data.", "error")
+            else
+              state.INFO = data
+            end
           end
-        end
+        end)
       end,
     }):start()
   end

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -27,55 +27,57 @@ local function current_file_path()
 end
 
 M.setup = function(args)
-  -- local file_path = current_file_path()
-  -- local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h")
-  --
-  -- state.BIN_PATH = parent_dir
-  -- state.BIN = parent_dir .. "/bin"
-  --
-  -- local binExists = io.open(state.BIN, "r")
-  -- if not binExists or args.dev == true then
-  --   local command = string.format("cd %s && make", state.BIN_PATH)
-  --   local installCode = os.execute(command .. "> /dev/null")
-  --   if installCode ~= 0 then
-  --     require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
-  --     return
-  --   end
-  -- end
-  --
-  -- if args.project_id == nil then
-  --   error("No project ID provided!")
-  -- end
-  -- state.PROJECT_ID = args.project_id
-  --
-  -- if args.base_branch ~= nil then
-  --   state.BASE_BRANCH = args.base_branch
-  -- end
-  --
-  -- if u.is_gitlab_repo() then
-  --   Job:new({
-  --     command = state.BIN,
-  --     args = { "info", state.PROJECT_ID },
-  --     on_stdout = function(_, line)
-  --       table.insert(projectData, line)
-  --     end,
-  --     on_stderr = u.print_error,
-  --     on_exit = function()
-  --       vim.schedule(function()
-  --         if projectData[1] ~= nil then
-  --           local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-  --           if parsed_ok ~= true then
-  --             require("notify")("Failed calling setup. Could not get project data.", "error")
-  --           else
-  --             state.INFO = data
-  --           end
-  --         end
-  --       end)
-  --     end,
-  --   }):start()
-  -- end
-  --
-  -- keymaps.set_keymap_keys(args.keymaps)
+  local file_path = current_file_path()
+  local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h")
+
+  state.BIN_PATH = parent_dir
+  state.BIN = parent_dir .. "/bin"
+
+  local binExists = io.open(state.BIN, "r")
+  if not binExists or args.dev == true then
+    local command = string.format("cd %s && make", state.BIN_PATH)
+    local installCode = os.execute(command .. "> /dev/null")
+    if installCode ~= 0 then
+      require("notify")("Could not install gitlab.nvim! Do you have Go installed?", "error")
+      return
+    end
+  end
+
+  if args.project_id == nil then
+    error("No project ID provided!")
+  end
+  state.PROJECT_ID = args.project_id
+
+  if args.base_branch ~= nil then
+    state.BASE_BRANCH = args.base_branch
+  end
+
+  vim.schedule(function()
+    if u.is_gitlab_repo() then
+      Job:new({
+        command = state.BIN,
+        args = { "info", state.PROJECT_ID },
+        on_stdout = function(_, line)
+          table.insert(projectData, line)
+        end,
+        on_stderr = u.print_error,
+        on_exit = function()
+          vim.schedule(function()
+            if projectData[1] ~= nil then
+              local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+              if parsed_ok ~= true then
+                require("notify")("Failed calling setup. Could not get project data.", "error")
+              else
+                state.INFO = data
+              end
+            end
+          end)
+        end,
+      }):start()
+    end
+  end)
+
+  keymaps.set_keymap_keys(args.keymaps)
 end
 
 return M

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -52,26 +52,26 @@ M.setup = function(args)
     state.BASE_BRANCH = args.base_branch
   end
 
-  -- if u.is_gitlab_repo() then
-  Job:new({
-    command = state.BIN,
-    args = { "info", state.PROJECT_ID },
-    on_stdout = function(_, line)
-      table.insert(projectData, line)
-    end,
-    on_stderr = u.print_error,
-    on_exit = function()
-      if projectData[1] ~= nil then
-        local parsed_ok, data = pcall(vim.json.decode, projectData[1])
-        if parsed_ok ~= true then
-          require("notify")("Failed calling setup. Could not get project data.", "error")
-        else
-          state.INFO = data
-        end
-      end
-    end,
-  }):start()
-  -- end
+  if u.is_gitlab_repo() then
+    Job:new({
+      command = state.BIN,
+      args = { "info", state.PROJECT_ID },
+      -- on_stdout = function(_, line)
+      --   table.insert(projectData, line)
+      -- end,
+      -- on_stderr = u.print_error,
+      -- on_exit = function()
+      --   if projectData[1] ~= nil then
+      --     local parsed_ok, data = pcall(vim.json.decode, projectData[1])
+      --     if parsed_ok ~= true then
+      --       require("notify")("Failed calling setup. Could not get project data.", "error")
+      --     else
+      --       state.INFO = data
+      --     end
+      --   end
+      -- end,
+    }):start()
+  end
 
   keymaps.set_keymap_keys(args.keymaps)
 end

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -56,10 +56,10 @@ M.setup = function(args)
     Job:new({
       command = state.BIN,
       args = { "info", state.PROJECT_ID },
-      -- on_stdout = function(_, line)
-      --   table.insert(projectData, line)
-      -- end,
-      on_stderr = u.print_error,
+      on_stdout = function(_, line)
+        table.insert(projectData, line)
+      end,
+      -- on_stderr = u.print_error,
       -- on_exit = function()
       --   if projectData[1] ~= nil then
       --     local parsed_ok, data = pcall(vim.json.decode, projectData[1])

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -1,4 +1,5 @@
 local state = require("gitlab.state")
+local notify = require("notify")
 
 local function get_git_root()
   local output = vim.fn.system('git rev-parse --show-toplevel 2>/dev/null')
@@ -66,14 +67,14 @@ local base_invalid = function()
   local current_branch = string.gsub(current_branch_raw, "\n", "")
 
   if current_branch == "main" or current_branch == "master" then
-    require("notify")('On ' .. current_branch .. ' branch, no MRs available', "error")
+    notify('On ' .. current_branch .. ' branch, no MRs available', "error")
     return true
   end
 
   local base = state.BASE_BRANCH
   local hasBaseBranch = feature_branch_exists(base)
   if not hasBaseBranch then
-    require("notify")('No base branch. If this is a Gitlab repository, please check your setup function!', "error")
+    notify('No base branch. If this is a Gitlab repository, please check your setup function!', "error")
     return true
   end
 end
@@ -153,13 +154,13 @@ end
 
 local function print_success(_, line)
   if line ~= nil and line ~= "" then
-    require("notify")(line, "info")
+    notify(line, "info")
   end
 end
 
 local function print_error(_, line)
   if line ~= nil and line ~= "" then
-    require("notify")(line, "error")
+    notify(line, "error")
   end
 end
 


### PR DESCRIPTION
Moves all `require` calls to notify out of the scheduled calls and into the top of the module. This fixes a bug where the plugin would not load for a fresh environment without notify previously loaded.