### PR TITLE
Ensure discussion splits open correctly

### DIFF
--- a/lua/gitlab/discussions.lua
+++ b/lua/gitlab/discussions.lua
@@ -52,7 +52,7 @@ M.list_discussions = function()
         vim.schedule(function()
           vim.cmd.tabnew()
           local buf = vim.api.nvim_create_buf(false, true)
-          vim.api.nvim_command("vsplit")
+          vim.api.nvim_command("aboveleft vsplit")
           vim.api.nvim_buf_set_option(buf, 'filetype', 'markdown')
           vim.api.nvim_set_current_buf(buf)
           local allDiscussions = {}


### PR DESCRIPTION
I found that if splitright was set to true the list of discussions would be populated in the right split and then the buffer would be taken over by the actual file. Leaving the left spilt blank. This just ensures that regardless of the users setting they open as expected.