### PR TITLE
Feat: Remove Notify Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ https://user-images.githubusercontent.com/32515581/233739969-216dad6e-fa77-417f-
 
 - Go
 - <a href="https://github.com/MunifTanjim/nui.nvim">nui.nvim</a>
-- <a href="https://github.com/rcarriga/nvim-notify">nvim-notify</a>
 - <a href="https://github.com/nvim-lua/plenary.nvim">plenary.nvim</a>
 
 ## Installation
@@ -31,14 +30,11 @@ Then install the plugin. Here's what it looks like with <a href="https://github.
 return {
   "harrisoncramer/gitlab.nvim",
   dependencies = {
-    "rcarriga/nvim-notify",
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim"
   },
   build = function () require("gitlab").build() end, -- Builds the Go binary
   config = function()
-    vim.opt.termguicolors = true -- This is required if you aren't already initializing notify
-    require("notify").setup({ background_colour = "#000000" })  -- This is required if you aren't already initializing notify
     require("gitlab").setup()
   end,
 }
@@ -50,15 +46,12 @@ And with Packer:
 use {
   'harrisoncramer/gitlab.nvim',
   requires = {
-    "rcarriga/nvim-notify",
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim"
   },
   run = function() require("gitlab").build() end,
   config = function()
-    vim.opt.termguicolors = true
-    require("notify").setup({ background_colour = "#000000" })
-    require("gitlab").setup() -- This can be found under the project details section of your Gitlab repository.
+    require("gitlab").setup()
   end,
 }
 ```

--- a/lua/gitlab/comment.lua
+++ b/lua/gitlab/comment.lua
@@ -1,6 +1,5 @@
 local Menu               = require("nui.menu")
 local NuiTree            = require("nui.tree")
-local notify             = require("notify")
 local job                = require("gitlab.job")
 local state              = require("gitlab.state")
 local u                  = require("gitlab.utils")
@@ -25,7 +24,7 @@ M.find_deletion_commit   = function(file)
   local handle = io.popen(command)
   local output = handle:read("*line")
   if output == nil then
-    notify("Error reading SHA of deletion commit", "error")
+    vim.notify("Error reading SHA of deletion commit", vim.log.levels.ERROR)
     return ""
   end
   handle:close()
@@ -111,7 +110,7 @@ M.delete_comment         = function()
 
         local json = string.format('{"discussion_id": "%s", "note_id": %d}', discussion_id, note_id)
         job.run_job("comment", "DELETE", json, function(data)
-          notify(data.message, "success")
+          vim.notify(data.message, vim.log.levels.INFO)
           state.tree:remove_node("-" .. note_id)
           local discussion_node = state.tree:get_node("-" .. discussion_id)
           if not discussion_node:has_children() then
@@ -179,7 +178,7 @@ M.send_edits   = function(text)
       state.tree:render()
       local buf = vim.api.nvim_get_current_buf()
       u.darken_metadata(buf, '')
-      notify("Edited comment!")
+      vim.notify("Edited comment!", vim.log.levels.INFO)
     end)
   end)
 end

--- a/lua/gitlab/discussions.lua
+++ b/lua/gitlab/discussions.lua
@@ -1,7 +1,6 @@
 local u            = require("gitlab.utils")
 local NuiTree      = require("nui.tree")
 local job          = require("gitlab.job")
-local notify       = require("notify")
 local state        = require("gitlab.state")
 local Job          = require("plenary.job")
 local Popup        = require("nui.popup")
@@ -29,7 +28,7 @@ M.send_reply       = function(text)
       state.tree:render()
       local buf = vim.api.nvim_get_current_buf()
       u.darken_metadata(buf, '')
-      notify("Sent reply!")
+      vim.notify("Sent reply!", vim.log.levels.INFO)
     end)
   end)
 end
@@ -45,7 +44,7 @@ M.list_discussions = function()
       if data_ok and data ~= nil then
         local status = (data.status >= 200 and data.status < 300) and "success" or "error"
         if status == "error" then
-          notify("Could not fetch discussions!", "error")
+          vim.notify("Could not fetch discussions!", vim.log.levels.ERROR)
           return
         end
         M.discussions = data.discussions
@@ -88,7 +87,7 @@ M.list_discussions = function()
       end
     end,
     on_stderr = function(_, output)
-      notify("Could not run approve command!", "error")
+      vim.notify("Could not run approve command!", vim.log.levels.ERROR)
       error(output)
     end,
   }):start()

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -1,6 +1,5 @@
 local curl         = require("plenary.curl")
 local state        = require("gitlab.state")
-local notify       = require("notify")
 local discussions  = require("gitlab.discussions")
 local summary      = require("gitlab.summary")
 local keymaps      = require("gitlab.keymaps")
@@ -24,7 +23,7 @@ local function build_binary()
   local command = string.format("cd %s && make", state.BIN_PATH)
   local installCode = os.execute(command .. "> /dev/null")
   if installCode ~= 0 then
-    notify("Could not install gitlab.nvim!", "error")
+    vim.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)
     return false
   end
   return true
@@ -71,19 +70,19 @@ M.setup = function(args)
     vim.fn.jobstart(state.BIN .. " " .. state.PROJECT_ID .. " " .. state.PORT, {
       on_stdout = function(job_id)
         if job_id <= 0 then
-          notify("Could not start gitlab.nvim binary", "error")
+          vim.notify("Could not start gitlab.nvim binary", vim.log.levels.ERROR)
           return
         else
           local response_ok, response = pcall(curl.get, "localhost:" .. state.PORT .. "/info",
             { timeout = 750 })
           if response == nil or not response_ok then
-            notify("The gitlab.nvim server did not respond", "error")
+            vim.notify("The gitlab.nvim server did not respond", vim.log.levels.ERROR)
             return
           end
           local body = response.body
           local parsed_ok, data = pcall(vim.json.decode, body)
           if parsed_ok ~= true then
-            notify("The gitlab.nvim server returned an invalid response to the /info endpoint", "error")
+            vim.notify("The gitlab.nvim server returned an invalid response to the /info endpoint", vim.log.levels.ERROR)
             return
           end
           state.INFO = data

--- a/lua/gitlab/job.lua
+++ b/lua/gitlab/job.lua
@@ -1,9 +1,8 @@
-local notify = require("notify")
-local Job    = require("plenary.job")
-local state  = require("gitlab.state")
-local M      = {}
+local Job   = require("plenary.job")
+local state = require("gitlab.state")
+local M     = {}
 
-M.run_job    = function(endpoint, method, body, callback)
+M.run_job   = function(endpoint, method, body, callback)
   local args = { "-s", "-X", (method or "POST"), string.format("localhost:%s/", state.PORT) .. endpoint }
 
   if body ~= nil then
@@ -20,26 +19,26 @@ M.run_job    = function(endpoint, method, body, callback)
         if callback ~= nil then
           callback(data)
         else
-          notify(data.message, status)
+          vim.notify(data.message, vim.log.levels.DEBUG)
         end
       else
-        notify("Could not parse command output!", "error")
+        vim.notify("Could not parse command output!", vim.log.levels.ERROR)
       end
     end,
     on_stderr = function(_, output)
-      notify("Could not run command!", "error")
+      vim.notify("Could not run command!", vim.log.levels.ERROR)
       error(output)
     end
   }):start()
 end
 
 -- Approves the current merge request
-M.approve    = function()
+M.approve   = function()
   M.run_job("approve", "POST")
 end
 
 -- Revokes approval for the current merge request
-M.revoke     = function()
+M.revoke    = function()
   M.run_job("revoke", "POST")
 end
 

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -1,5 +1,4 @@
 local state = require("gitlab.state")
-local notify = require("notify")
 
 local function get_git_root()
   local output = vim.fn.system('git rev-parse --show-toplevel 2>/dev/null')
@@ -81,14 +80,14 @@ local base_invalid = function()
   local current_branch = string.gsub(current_branch_raw, "\n", "")
 
   if current_branch == "main" or current_branch == "master" then
-    notify('On ' .. current_branch .. ' branch, no MRs available', "error")
+    vim.notify('On ' .. current_branch .. ' branch, no MRs available', vim.log.levels.ERROR)
     return true
   end
 
   local base = state.BASE_BRANCH
   local hasBaseBranch = feature_branch_exists(base)
   if not hasBaseBranch then
-    notify('No base branch. If this is a Gitlab repository, please check your setup function!', "error")
+    vim.notify('No base branch. If this is a Gitlab repository, please check your setup function!', vim.log.levels.ERROR)
     return true
   end
 end
@@ -169,13 +168,13 @@ end
 
 local function print_success(_, line)
   if line ~= nil and line ~= "" then
-    notify(line, "info")
+    vim.notify(line, vim.log.levels.INFO)
   end
 end
 
 local function print_error(_, line)
   if line ~= nil and line ~= "" then
-    notify(line, "error")
+    vim.notify(line, vim.log.levels.ERROR)
   end
 end
 


### PR DESCRIPTION
Addresses some comments from Reddit who pointed out that you don't need to have notify as a dependency.

If folks want to use notify they can set the `vim.notify = require("notify")` in their own configuration.