### PR TITLE
Feat: Pull down all non-code notes

### DIFF
--- a/cmd/list_discussions.go
+++ b/cmd/list_discussions.go
@@ -44,18 +44,18 @@ func (c *Client) ListDiscussions() ([]*gitlab.Discussion, int, error) {
 		return nil, res.Response.StatusCode, fmt.Errorf("Listing discussions failed: %w", err)
 	}
 
-	var realDiscussions []*gitlab.Discussion
+	var diffNotes []*gitlab.Discussion
 	for i := 0; i < len(discussions); i++ {
 		notes := discussions[i].Notes
 		for j := 0; j < len(notes); j++ {
-			if notes[j].Type == gitlab.NoteTypeValue("DiffNote") {
-				realDiscussions = append(realDiscussions, discussions[i])
+			if !notes[j].System {
+				diffNotes = append(diffNotes, discussions[i])
 				break
 			}
 		}
 	}
 
-	sortedDiscussions := SortableDiscussions(realDiscussions)
+	sortedDiscussions := SortableDiscussions(diffNotes)
 	sort.Sort(sortedDiscussions)
 
 	return sortedDiscussions, http.StatusOK, nil

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -131,7 +131,7 @@ end
 
 
 local function jump_to_file(filename, line_number)
-  if line_number == nil then line_number = 1 end
+  if line_number == nil or filename == nil then return end
   vim.api.nvim_command("wincmd l")
   local bufnr = vim.fn.bufnr(filename)
   if bufnr ~= -1 then


### PR DESCRIPTION
This commit changes the filter on the API response so that we are only filtering out system level notes. This means we get notes that are not linked to specific locations in the code.

Subsequent work will have to separate these types of notes from the other code-linked notes and probably display them in some sort of separate tree.