### PR TITLE
Refresh Tree on Delete

### DIFF
--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -88,9 +88,9 @@ func DeleteComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(res.StatusCode)
-
 	/* TODO: Check status code */
+	w.WriteHeader(http.StatusOK)
+
 	response := SuccessResponse{
 		Message: "Comment deleted succesfully",
 		Status:  http.StatusOK,

--- a/lua/gitlab/comment.lua
+++ b/lua/gitlab/comment.lua
@@ -40,7 +40,7 @@ M.confirm_create_comment = function(text)
   local jsonTable = { line_number = current_line_number, file_name = relative_file_path, comment = text }
   local json = vim.json.encode(jsonTable)
 
-  job.run_job("comment", "POST", json, function()
+  job.run_job("comment", "POST", json, function(data)
     vim.notify("Comment created")
     discussions.refresh_tree()
   end)
@@ -93,7 +93,17 @@ M.send_deletion          = function(item)
     local json = vim.json.encode(jsonTable)
 
     job.run_job("comment", "DELETE", json, function(data)
-      M.delete_node()
+      vim.notify(data.message, vim.log.levels.INFO)
+      if not note_node.is_root then
+        state.tree:remove_node("-" .. note_id)
+        state.tree:render()
+      else
+        -- We are removing the root node of the discussion,
+        -- we need to move all the children around, the easiest way
+        -- to do this is to just re-render the whole tree 🤷
+        discussions.refresh_tree()
+        note_node:expand()
+      end
     end)
   end
 end


### PR DESCRIPTION
We weren't writing a 200 status code post-delete because Gitlab returns a 204 (empty but successful) by default. I updated this logic to change that and also to refresh the tree.

The collapsed state of the tree will be wiped out if you delete a bottom-level discussion but that's okay for now, not a high priority right now.