### PR TITLE
Attach UUIDs to Discussion Text

### DIFF
--- a/lua/gitlab/discussions.lua
+++ b/lua/gitlab/discussions.lua
@@ -137,8 +137,14 @@ end
 M.build_note_body          = function(note)
   local text_nodes = {}
   for bodyLine in note.body:gmatch("[^\n]+") do
-    table.insert(text_nodes, NuiTree.Node({ text = bodyLine, is_body = true }, {}))
+    local line = u.clean_comment_body(bodyLine)
+    table.insert(text_nodes, NuiTree.Node({
+      text = line.text,
+      id = line.id,
+      is_body = true
+    }, {}))
   end
+
   local noteHeader = "@" ..
       note.author.username .. " " .. u.format_date(note.created_at)
 

--- a/lua/gitlab/discussions.lua
+++ b/lua/gitlab/discussions.lua
@@ -137,7 +137,7 @@ end
 M.build_note_body          = function(note)
   local text_nodes = {}
   for bodyLine in note.body:gmatch("[^\n]+") do
-    local line = u.clean_comment_body(bodyLine)
+    local line = u.attach_uuid(bodyLine)
     table.insert(text_nodes, NuiTree.Node({
       text = line.text,
       id = line.id,

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -245,7 +245,7 @@ local current_file_path = function()
 end
 
 -- Function to join two tables
-function join_tables(table1, table2)
+local function join_tables(table1, table2)
   for _, value in ipairs(table2) do
     table.insert(table1, value)
   end
@@ -253,6 +253,20 @@ function join_tables(table1, table2)
   return table1
 end
 
+local random = math.random
+local function uuid()
+  local template = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+  return string.gsub(template, '[xy]', function(c)
+    local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
+    return string.format('%x', v)
+  end)
+end
+
+local clean_comment_body = function(str)
+  return { text = str, id = uuid() }
+end
+
+M.clean_comment_body = clean_comment_body
 M.join_tables = join_tables
 M.get_relative_file_path = get_relative_file_path
 M.get_current_line_number = get_current_line_number

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -262,11 +262,11 @@ local function uuid()
   end)
 end
 
-local clean_comment_body = function(str)
+local attach_uuid = function(str)
   return { text = str, id = uuid() }
 end
 
-M.clean_comment_body = clean_comment_body
+M.attach_uuid = attach_uuid
 M.join_tables = join_tables
 M.get_relative_file_path = get_relative_file_path
 M.get_current_line_number = get_current_line_number


### PR DESCRIPTION
Three backticks will break the discussion tree, this MR specifically adds custom UUIDs to each text node to avoid this issue.