### PR TITLE
Bugfix: Don't Start Server Right Away

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,7 @@ If you don't want to write your authentication token into a dotfile, you may pro
 export GITLAB_TOKEN="your_gitlab_token"
 ```
 
-By default, the plugin will interact with MRs against a "main" branch. You can configure this by passing in the `base_branch` option to the `.gitlab.nvim` configuration file for your project.
-
-```
-project_id=112415
-auth_token=your_gitlab_token
-gitlab_url=https://my-personal-gitlab-instance.com/
-base_branch=master
-```
-
 ## Configuring the Plugin
-
 
 Here is the default setup function. All of these values are optional, and if you call this function with no values the defaults will be used:
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,7 @@ func main() {
 	var c Client
 
 	if err := c.init(branchName); err != nil {
-		log.Fatalf("Failure: Failed to initialize client: %v", err)
+		log.Fatalf("Failed to initialize Gitlab client: %v", err)
 	}
 
 	m := http.NewServeMux()

--- a/lua/gitlab/comment.lua
+++ b/lua/gitlab/comment.lua
@@ -13,14 +13,12 @@ local edit_popup         = Popup(u.create_popup_state("Edit Comment", "80%", "80
 
 -- Function that fires to open the comment popup
 M.create_comment         = function()
-  if u.base_invalid() then return end
   comment_popup:mount()
   keymaps.set_popup_keymaps(comment_popup, M.confirm_create_comment)
 end
 
 -- Actually sends the comment to Gitlab
 M.confirm_create_comment = function(text)
-  if u.base_invalid() then return end
   local relative_file_path = u.get_relative_file_path()
   local current_line_number = u.get_current_line_number()
   if relative_file_path == nil then return end
@@ -110,7 +108,6 @@ end
 
 -- Function that opens the edit popup from the discussion tree
 M.edit_comment           = function()
-  if u.base_invalid() then return end
   local current_node = state.tree:get_node()
   local note_node = discussions.get_note_node(current_node)
   local root_node = discussions.get_root_node(current_node)

--- a/lua/gitlab/discussions.lua
+++ b/lua/gitlab/discussions.lua
@@ -11,7 +11,6 @@ local M                    = {}
 local replyPopup           = Popup(u.create_popup_state("Reply", "80%", "80%"))
 
 M.reply                    = function(discussion_id)
-  if u.base_invalid() then return end
   replyPopup:mount()
   keymaps.set_popup_keymaps(replyPopup, M.send_reply(discussion_id))
 end
@@ -28,7 +27,6 @@ end
 
 -- Places all of the discussions into a readable list
 M.list_discussions         = function()
-  if u.base_invalid() then return end
   job.run_job("discussions", "GET", nil, function(data)
     if type(data.discussions) ~= "table" then
       vim.notify("No discussions for this MR")

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -58,7 +58,6 @@ M.ensureState                 = function(callback)
           return
         else
           keymaps.set_keymap_keys(state.args.keymaps)
-          keymaps.set_keymaps()
 
           -- Once the Go binary has started, call the info endpoint
           -- to set global state for other commands
@@ -73,11 +72,13 @@ M.ensureState                 = function(callback)
         end
       end,
       on_stderr = function(_, errors)
+        local err_msg = ''
         for _, err in ipairs(errors) do
           if err ~= "" and err ~= nil then
-            vim.notify(err, vim.log.levels.ERROR)
+            err_msg = err_msg .. err .. "\n"
           end
         end
+        vim.notify(err_msg, vim.log.levels.ERROR)
       end
     })
   end
@@ -126,20 +127,14 @@ M.setPluginConfiguration      = function(args)
 
   local project_id = property["project_id"]
   local gitlab_url = property["gitlab_url"]
-  local base_branch = property["base_branch"]
   local auth_token = property["auth_token"]
 
   state.PROJECT_ID = project_id
   state.AUTH_TOKEN = auth_token or os.getenv("GITLAB_TOKEN")
   state.GITLAB_URL = gitlab_url or "https://gitlab.com"
-  state.BASE_BRANCH = base_branch or "main"
 
   local current_branch_raw = io.popen("git rev-parse --abbrev-ref HEAD"):read("*a")
   local current_branch = string.gsub(current_branch_raw, "\n", "")
-
-  if current_branch == state.BASE_BRANCH then
-    return false
-  end
 
   if state.AUTH_TOKEN == nil then
     error("Missing authentication token for Gitlab")

--- a/lua/gitlab/keymaps.lua
+++ b/lua/gitlab/keymaps.lua
@@ -19,30 +19,4 @@ M.set_keymap_keys   = function(keyTable)
   state.keymaps = u.merge_tables(state.keymaps, keyTable)
 end
 
-M.set_keymaps       = function()
-  local ok, _ = pcall(require, "diffview")
-  vim.keymap.set("n", state.keymaps.review.toggle, function()
-    if not ok then
-      require("notify")("You must have diffview.nvim installed to use this command!", "error")
-      return
-    end
-    local isDiff = vim.fn.getwinvar(nil, "&diff")
-    local bufName = vim.api.nvim_buf_get_name(0)
-    local has_develop = u.branch_exists("main") -- TODO: Write this function
-    if not has_develop then
-      require("notify")('No ' .. state.BASE_BRANCH .. ' branch, cannot review.', "error")
-      return
-    end
-    if isDiff ~= 0 or u.string_starts(bufName, "diff") then
-      vim.cmd.tabclose()
-      vim.cmd.tabprev()
-    else
-      vim.cmd.DiffviewOpen(state.BASE_BRANCH)
-      u.press_enter()
-    end
-  end)
-end
-
-
-
 return M

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -5,7 +5,6 @@ M.BIN               = nil
 M.PROJECT_ID        = nil
 M.ACTIVE_DISCUSSION = nil
 M.ACTIVE_NOTE       = nil
-M.BASE_BRANCH       = "main"
 M.keymaps           = {
   popup = {
     exit = "<Esc>",

--- a/lua/gitlab/summary.lua
+++ b/lua/gitlab/summary.lua
@@ -7,7 +7,6 @@ local descriptionPopup = Popup(u.create_popup_state("Loading Description...", "8
 local M                = {}
 
 M.summary              = function()
-  if u.base_invalid() then return end
   descriptionPopup:mount()
   local currentBuffer = vim.api.nvim_get_current_buf()
   local title = state.INFO.title

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -54,44 +54,12 @@ local function get_buffer_text(bufnr)
   return text
 end
 
-local feature_branch_exists = function(base_branch)
-  local is_git_branch = io.popen("git rev-parse --is-inside-work-tree 2>/dev/null"):read("*a")
-  if is_git_branch == "true\n" then
-    for line in io.popen("git branch 2>/dev/null"):lines() do
-      line = line:gsub("%s+", "")
-      if line == base_branch then
-        return true
-      end
-    end
-  end
-  return false
-end
-
 local string_starts = function(str, start)
   return str:sub(1, #start) == start
 end
 
 local press_enter = function()
   vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", false, true, true), "n", false)
-end
-
-local base_invalid = function()
-  local current_branch_raw = io.popen("git rev-parse --abbrev-ref HEAD"):read("*a")
-  local current_branch = string.gsub(current_branch_raw, "\n", "")
-
-  if current_branch == "main" or current_branch == "master" then
-    vim.notify('On ' .. current_branch .. ' branch, no MRs available', vim.log.levels.ERROR)
-    return true
-  end
-
-  local base = state.BASE_BRANCH
-  local hasBaseBranch = feature_branch_exists(base)
-  if not hasBaseBranch then
-    vim.notify(
-      'Could not fetch feature branch. Please check that you have the correct base_branch value set in your .gitlab.nvim configuration file',
-      vim.log.levels.ERROR)
-    return true
-  end
 end
 
 local format_date = function(date_string)
@@ -302,10 +270,8 @@ M.join_tables = join_tables
 M.get_relative_file_path = get_relative_file_path
 M.get_current_line_number = get_current_line_number
 M.get_buffer_text = get_buffer_text
-M.feature_branch_exists = feature_branch_exists
 M.press_enter = press_enter
 M.string_starts = string_starts
-M.base_invalid = base_invalid
 M.format_date = format_date
 M.add_comment_sign = add_comment_sign
 M.jump_to_file = jump_to_file


### PR DESCRIPTION
Previously we were attempting to start up the Golang server whenever someone opened a feature branch. This was problematic because the plugin would try to look for an MR on feature branches where none existed yet.

This MR modifies the startup calls so that the server is only initialized after you run any of the commands provided by the plugin, as specified in the root module. This ensures that we'll only try to connect to Gitlab when the _user believes_ that an MR actually exists for the current feature branch.