### PR TITLE
Feat: Windows Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ https://github.com/harrisoncramer/gitlab.nvim/assets/32515581/ab5a8597-32fa-4a28
 ## Requirements
 
 - <a href="https://go.dev/">Go >= v1.19</a>
-- <a href="https://www.gnu.org/software/make/manual/make.html">make (for install)</a>
 
 ## Quick Start
 
@@ -63,7 +62,7 @@ use {
 }
 ```
 
-## Configuration
+## Project Configuration
 
 This plugin requires a `.gitlab.nvim` file in the root of the project. Provide this file with values required to connect to your gitlab instance of your repository (gitlab_url is optional, use ONLY for self-hosted instances):
 

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -46,7 +46,7 @@ M.build = function(override)
   local file_path = u.current_file_path()
   local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h:h")
   state.settings.bin_path = parent_dir
-  state.settings.bin = parent_dir .. "/bin"
+  state.settings.bin = parent_dir .. u.is_windows() and "\\bin" or "/bin"
 
   if not override then
     local binary_exists = vim.loop.fs_stat(state.settings.bin)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -54,13 +54,13 @@ M.build = function(override)
   end
 
   local cmd = u.is_windows() and
-      'cd cmd && go build -o bin && move bin ..\\bin' or
+      'cd cmd && go build -o bin && move bin ..\\' or
       'cd cmd && go build -o bin && mv bin ../bin'
 
   local command = string.format(cmd, state.settings.bin_path)
-  local null = u.is_windows() and "NUL" or "/dev/null"
-  print(command .. "> " .. null)
-  local installCode = os.execute(command .. " > " .. null)
+  local null = u.is_windows() and " >NUL" or " > /dev/null"
+  print(command .. null)
+  local installCode = os.execute(command .. null)
   if installCode ~= 0 then
     vim.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)
     return false

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -58,7 +58,8 @@ M.build = function(override)
       'cd cmd && go build -o bin && mv bin ../bin'
 
   local command = string.format(cmd, state.settings.bin_path)
-  local installCode = os.execute(command .. "> /dev/null")
+  local null = u.is_windows() and "NUL" or "/dev/null"
+  local installCode = os.execute(command .. "> " .. null)
   if installCode ~= 0 then
     vim.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)
     return false

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -59,6 +59,7 @@ M.build = function(override)
 
   local command = string.format(cmd, state.settings.bin_path)
   local null = u.is_windows() and "NUL" or "/dev/null"
+  print(command .. "> " .. null)
   local installCode = os.execute(command .. "> " .. null)
   if installCode ~= 0 then
     vim.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -60,7 +60,7 @@ M.build = function(override)
   local command = string.format(cmd, state.settings.bin_path)
   local null = u.is_windows() and "NUL" or "/dev/null"
   print(command .. "> " .. null)
-  local installCode = os.execute(command .. "> " .. null)
+  local installCode = os.execute(command .. " > " .. null)
   if installCode ~= 0 then
     vim.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)
     return false

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -46,7 +46,7 @@ M.build = function(override)
   local file_path = u.current_file_path()
   local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h:h")
   state.settings.bin_path = parent_dir
-  state.settings.bin = parent_dir .. u.is_windows() and "\\bin" or "/bin"
+  state.settings.bin = parent_dir .. (u.is_windows() and "\\bin" or "/bin")
 
   if not override then
     local binary_exists = vim.loop.fs_stat(state.settings.bin)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -46,7 +46,7 @@ M.build = function(override)
   local file_path = u.current_file_path()
   local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h:h")
   state.settings.bin_path = parent_dir
-  state.settings.bin = parent_dir .. (u.is_windows() and "\\bin" or "/bin")
+  state.settings.bin = parent_dir .. (u.is_windows() and "\\bin.exe" or "/bin")
 
   if not override then
     local binary_exists = vim.loop.fs_stat(state.settings.bin)
@@ -54,7 +54,7 @@ M.build = function(override)
   end
 
   local cmd = u.is_windows() and
-      'cd cmd && go build -o bin && move bin ..\\' or
+      'cd cmd && go build -o bin.exe && move bin.exe ..\\' or
       'cd cmd && go build -o bin && mv bin ../bin'
 
   local command = string.format(cmd, state.settings.bin_path)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -53,7 +53,11 @@ M.build = function(override)
     if binary_exists ~= nil then return end
   end
 
-  local command = string.format("cd %s && make", state.settings.bin_path)
+  local cmd = u.is_windows() and
+      'cd cmd && go build -o bin && move bin ..\\bin' or
+      'cd cmd && go build -o bin && mv bin ../bin'
+
+  local command = string.format(cmd, state.settings.bin_path)
   local installCode = os.execute(command .. "> /dev/null")
   if installCode ~= 0 then
     vim.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -19,6 +19,13 @@ M.has_reviewer = function(reviewer)
   return has_reviewer
 end
 
+M.is_windows = function()
+  if vim.fn.has("win32") == 1 or vim.fn.has("win32unix") == 1 then
+    return true
+  end
+  return false
+end
+
 M.P = function(...)
   local objects = {}
   for i = 1, select("#", ...) do


### PR DESCRIPTION
This MR adds support for Windows. The binary is installed as `bin.exe` and executed as per usual.

Since Windows does not have `make` natively I've also removed that as a dependency.

Addresses #34 