### PR TITLE
#60 Automatically Detect Stale Branches

### DIFF
--- a/lua/gitlab/async.lua
+++ b/lua/gitlab/async.lua
@@ -45,6 +45,12 @@ end
 -- Will call APIs in sequence and set global state
 M.sequence = function(dependencies, cb)
   return function(argTable)
+    local branch = vim.fn.system({ "git", "rev-parse", "--abbrev-ref", "HEAD" }):gsub("%s+", "")
+    if branch == "main" or branch == "master" then
+      vim.notify("Must check out feature branch", vim.log.levels.ERROR)
+      return
+    end
+
     local handler = Async:new()
     handler:init(cb)
 

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -95,9 +95,6 @@ M.ready_to_review = function()
     return nil, nil, string.format("Error checking status of %s branch", state.INFO.source_branch)
   end
 
-  print(string.format("Your target branch output is: %s", target_output))
-  print(string.format("Your source branch output is: %s", source_output))
-
   if target_output ~= "" or source_output ~= "" then
     return target_output ~= "", source_output ~= "", nil
   end

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -13,6 +13,7 @@ local reviewer_map = {
   diffview = diffview
 }
 
+
 M.init = function()
   local reviewer = reviewer_map[state.settings.reviewer]
   if reviewer == nil then
@@ -20,8 +21,49 @@ M.init = function()
     return
   end
 
-  M.open = reviewer.open
-  -- Opens the reviewer window
+  -- Opens the reviewer window. If either branch is out of date,
+  -- prompts the user to pull down, then opens the reviewer
+  M.open = function()
+    local branch = vim.fn.system({ "git", "rev-parse", "--abbrev-ref", "HEAD" }):gsub("%s+", "")
+    if branch == "main" or branch == "master" then
+      return -- Must run reviews on feature branches
+    end
+
+    local target_not_ready, source_not_ready, err = M.ready_to_review(state.INFO.source_branch)
+    if err then
+      vim.notify(err, vim.log.levels.ERROR)
+      return
+    end
+
+    if target_not_ready or source_not_ready then
+      local opts = {
+        string.format("Yes, pull \"%s\" and/or \"%s\"", state.INFO.source_branch, state.INFO.target_branch), "No, cancel" }
+      vim.ui.select(opts, {
+        prompt =
+        'Your local repository is out-of-date. Pull branches?',
+      }, function(choice)
+        if not choice or choice == "No, cancel" then return end
+        if target_not_ready then
+          vim.fn.system({ "git", "pull", "--no-edit", "--no-rebase", "--ff-only", "origin", state.INFO.target_branch })
+          if vim.v.shell_error ~= 0 then
+            vim.notify(string.format("Could not pull %s branch", state.INFO.target_branch), vim.log.levels.ERROR)
+            return
+          end
+        end
+        if source_not_ready then
+          vim.fn.system({ "git", "pull", "--no-edit", "--no-rebase", "--ff-only", "origin", state.INFO.source_branch })
+          if vim.v.shell_error ~= 0 then
+            vim.notify(string.format("Could not pull %s branch", state.INFO.source_branch), vim.log.levels.ERROR)
+            return
+          end
+        end
+
+        reviewer.open()
+      end)
+    else
+      reviewer.open()
+    end
+  end
 
   M.jump = reviewer.jump
   -- Jumps to the location provided in the reviewer window
@@ -35,5 +77,32 @@ M.init = function()
   -- file_name, {new_line, old_line}, error
 end
 
+M.ready_to_review = function()
+  vim.fn.system({ "git", "fetch" })
+  if vim.v.shell_error ~= 0 then
+    return nil, nil, "Could not fetch remote changes"
+  end
+
+  local target_output = vim.fn.system({ "git", "rev-list",
+    string.format("%s..origin/%s", state.INFO.target_branch, state.INFO.target_branch) })
+  if vim.v.shell_error ~= 0 then
+    return nil, nil, string.format("Error checking status of %s branch", state.INFO.target_branch)
+  end
+
+  local source_output = vim.fn.system({ "git", "rev-list",
+    string.format("%s..origin/%s", state.INFO.source_branch, state.INFO.source_branch) })
+  if vim.v.shell_error ~= 0 then
+    return nil, nil, string.format("Error checking status of %s branch", state.INFO.source_branch)
+  end
+
+  print(string.format("Your target branch output is: %s", target_output))
+  print(string.format("Your source branch output is: %s", source_output))
+
+  if target_output ~= "" or source_output ~= "" then
+    return target_output ~= "", source_output ~= "", nil
+  end
+
+  return nil, nil, nil
+end
 
 return M

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -24,12 +24,7 @@ M.init = function()
   -- Opens the reviewer window. If either branch is out of date,
   -- prompts the user to pull down, then opens the reviewer
   M.open = function()
-    local branch = vim.fn.system({ "git", "rev-parse", "--abbrev-ref", "HEAD" }):gsub("%s+", "")
-    if branch == "main" or branch == "master" then
-      return -- Must run reviews on feature branches
-    end
-
-    local target_not_ready, source_not_ready, err = M.ready_to_review(state.INFO.source_branch)
+    local target_not_ready, source_not_ready, err = M.ready_to_review()
     if err then
       vim.notify(err, vim.log.levels.ERROR)
       return


### PR DESCRIPTION
This adds a check into the open reviewer functionality that will automatically detect whether either the target or source branch is out of date and prompt the reviewer to pull them both down.

Addresses #60