### PR TITLE
Fixes #70

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,12 +88,9 @@ func main() {
 
 }
 
-type ClientString string
-
 func withGitlabContext(next http.HandlerFunc, c Client) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var cl ClientString = "client"
-		ctx := context.WithValue(context.Background(), cl, c)
+		ctx := context.WithValue(context.Background(), "client", c) //nolint:all
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
Discovery of the client on the context of the requests was not working due to this issue, which was a linting related change.