### PR TITLE
Discussion sign and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ https://github.com/harrisoncramer/gitlab.nvim/assets/32515581/50f44eaf-5f99-4cb3
 ## Quick Start
 
 1. Install Go
-3. Add configuration (see Installation section)
-4. Checkout your feature branch: `git checkout feature-branch`
-5. Open Neovim
-6. Run `:lua require("gitlab").review()` to open the reviewer pane
+2. Add configuration (see Installation section)
+3. Checkout your feature branch: `git checkout feature-branch`
+4. Open Neovim
+5. Run `:lua require("gitlab").review()` to open the reviewer pane
 
 ## Installation
 
@@ -66,7 +66,7 @@ use {
 
 ## Project Configuration
 
-This plugin requires an <a href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token">auth token</a> to connect to Gitlab. The token can be set in the root directory of the project in a `.gitlab.nvim` environment file, or can be set via a shell environment variable called `GITLAB_TOKEN` instead. If both are present, the `.gitlab.nvim` file will take precedence. 
+This plugin requires an <a href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token">auth token</a> to connect to Gitlab. The token can be set in the root directory of the project in a `.gitlab.nvim` environment file, or can be set via a shell environment variable called `GITLAB_TOKEN` instead. If both are present, the `.gitlab.nvim` file will take precedence.
 
 Optionally provide a GITLAB_URL environment variable (or gitlab_url value in the `.gitlab.nvim` file) to connect to a self-hosted Gitlab instance. This is optional, use ONLY for self-hosted instances.
 
@@ -112,6 +112,23 @@ require("gitlab").setup({
     resolved = '✓', -- Symbol to show next to resolved discussions
     unresolved = '✖', -- Symbol to show next to unresolved discussions
   },
+  discussion_sign = {
+    -- See :h sign_define for details about sign configuration.
+    enabled = true,
+    text = "💬",
+    linehl = nil,
+    texthl = nil,
+    culhl = nil,
+    numhl = nil,
+  },
+  discussion_diagnostics = {
+    -- If you want to customize diagnostics for discussions you can make special config
+    -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
+    enabled = true,
+    severity = vim.diagnostic.severity.INFO,
+    code = nil, -- see :h diagnostic-structure
+    display_opts = {}, -- see opts in vim.diagnostic.set
+  },
   pipeline = {
     created = "",
     pending = "",
@@ -145,7 +162,7 @@ Then open Neovim. To begin, try running the `summary` command or the `review` co
 
 ### Summary
 
-The `summary` action will open the MR title and description. 
+The `summary` action will open the MR title and description.
 
 ```lua
 require("gitlab").summary()
@@ -186,6 +203,14 @@ If you'd like to create a note in an MR (like a comment, but not linked to a spe
 
 ```lua
 require("gitlab").create_note()
+```
+
+### Discussions signs and diagnostics
+
+By default when reviewing files you will see signs and diagnostics ( if enabled in configuration ). When cursor is on diagnostic line you can view discussion thread by using `vim.diagnostic.show`. You can also jump to discussion tree where you can reply, edit or delete discussion.
+
+```lua
+require("gitlab").jump_to_discussion_tree_from_diagnostic()
 ```
 
 ### Uploading Files
@@ -249,6 +274,7 @@ vim.keymap.set("n", "<leader>glR", gitlab.revoke)
 vim.keymap.set("n", "<leader>glc", gitlab.create_comment)
 vim.keymap.set("v", "<leader>glc", gitlab.create_multiline_comment)
 vim.keymap.set("v", "<leader>glC", gitlab.create_comment_suggestion)
+vim.keymap.set("n", "<leader>glj", gitlab.jump_to_discussion_tree_from_diagnostic)
 vim.keymap.set("n", "<leader>gln", gitlab.create_note)
 vim.keymap.set("n", "<leader>gld", gitlab.toggle_discussions)
 vim.keymap.set("n", "<leader>glaa", gitlab.add_assignee)

--- a/README.md
+++ b/README.md
@@ -228,12 +228,10 @@ require("gitlab").move_to_discussion_tree_from_diagnostic()
 
 The `discussion_sign` configuration controls the display of signs for discussions. The `enabled` option turns on/off the signs. `text` sets the sign text. `linehl`, `texthl`, `culhl`, and `numhl` customize the line highlighting, text highlighting, column highlighting, and number highlighting respectively. Keep in mind that these can be overridden by other configuration (for example diffview.nvim highlights). `priority` controls the sign priority order (when multiple signs are placed on the same line, the sign with highest priority is used). The `helper_signs` table configures additional signs for multiline discussions in order to show the whole context. `enabled` turns on/off the helper signs. `start`, `mid`, and `end` set the helper sign text.
 
-The `discussion_diagnostic` configuration customizes the diagnostic display for discussions. The `enabled` option turns on/off the diagnostics. `severity` sets the diagnostic severity level and should be set to one of `vim.diagnostic.severity.ERROR`, `vim.diagnostic.severity.WARN`, or `vim.diagnostic.severity.INFO`, `vim.diagnostic.severity.HINT`. `code` specifies a diagnostic code. `display_opts` configures the diagnostic display options where you can configure values like:
+The `discussion_diagnostic` configuration customizes the diagnostic display for discussions. The `enabled` option turns on/off the diagnostics. `severity` sets the diagnostic severity level and should be set to one of `vim.diagnostic.severity.ERROR`, `vim.diagnostic.severity.WARN`, or `vim.diagnostic.severity.INFO`, `vim.diagnostic.severity.HINT`. `code` specifies a diagnostic code. `display_opts` configures the diagnostic display options where you can configure values like (this is dirrectly used as opts in vim.diagnostic.set):
 
 - `virtual_text` - Show virtual text for diagnostics.
 - `underline` - Underline text for diagnostics.
-- `severity_sort` - Sort diagnostics by severity.
-- `float` - Show diagnostics in a floating window.
 
 Diagnostics for discussions use the `gitlab_discussion` namespace. See `:h vim.diagnostic.config` and `:h diagnostic-structure` for more details.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ require("gitlab").setup({
     resolved = '✓', -- Symbol to show next to resolved discussions
     unresolved = '✖', -- Symbol to show next to unresolved discussions
   },
+  discussion_sign_and_diagnostic = {
+    skip_resolved_discussion = false,
+    skip_old_revision_discussion = true,
+  },
   discussion_sign = {
     -- See :h sign_define for details about sign configuration.
     enabled = true,
@@ -120,7 +124,7 @@ require("gitlab").setup({
     texthl = nil,
     culhl = nil,
     numhl = nil,
-    priority = 20,
+    priority = 20, -- Priority of sign, the lower the number the higher the priority
     helper_signs = {
       -- For multiline comments the helper signs are used to indicate the whole context
       -- Priority of helper signs is lower than the main sign (-1).
@@ -130,7 +134,7 @@ require("gitlab").setup({
       ["end"] = "↓",
     },
   },
-  discussion_diagnostics = {
+  discussion_diagnostic = {
     -- If you want to customize diagnostics for discussions you can make special config
     -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,
@@ -219,8 +223,24 @@ require("gitlab").create_note()
 By default when reviewing files you will see signs and diagnostics ( if enabled in configuration ). When cursor is on diagnostic line you can view discussion thread by using `vim.diagnostic.show`. You can also jump to discussion tree where you can reply, edit or delete discussion.
 
 ```lua
-require("gitlab").jump_to_discussion_tree_from_diagnostic()
+require("gitlab").move_to_discussion_tree_from_diagnostic()
 ```
+
+The `discussion_sign` configuration controls the display of signs for discussions. The `enabled` option turns on/off the signs. `text` sets the sign text. `linehl`, `texthl`, `culhl`, and `numhl` customize the line highlighting, text highlighting, column highlighting, and number highlighting respectively. Keep in mind that these can be overridden by other configuration (for example diffview.nvim highlights). `priority` controls the sign priority order (when multiple signs are placed on the same line, the sign with highest priority is used). The `helper_signs` table configures additional signs for multiline discussions in order to show the whole context. `enabled` turns on/off the helper signs. `start`, `mid`, and `end` set the helper sign text.
+
+The `discussion_diagnostic` configuration customizes the diagnostic display for discussions. The `enabled` option turns on/off the diagnostics. `severity` sets the diagnostic severity level and should be set to one of `vim.diagnostic.severity.ERROR`, `vim.diagnostic.severity.WARN`, or `vim.diagnostic.severity.INFO`, `vim.diagnostic.severity.HINT`. `code` specifies a diagnostic code. `display_opts` configures the diagnostic display options where you can configure values like:
+
+- `virtual_text` - Show virtual text for diagnostics.
+- `underline` - Underline text for diagnostics.
+- `severity_sort` - Sort diagnostics by severity.
+- `float` - Show diagnostics in a floating window.
+
+Diagnostics for discussions use the `gitlab_discussion` namespace. See `:h vim.diagnostic.config` and `:h diagnostic-structure` for more details.
+
+Signs and diagnostics have common settings in `discussion_sign_and_diagnostics`. This allows customizing if discussions that are resolved or no longer relevant should still display visual indicators in the editor:
+
+- `skip_resolved_discussion` - Whether to skip showing signs and diagnostics for resolved discussions. Default is `false`, meaning signs and diagnostics will be shown for resolved discussions.
+- `skip_old_revision_discussion` - Whether to skip showing signs and diagnostics for discussions on outdated diff revisions. Default is `true`, meaning signs and diagnostics won't be shown for discussions no longer relevant to the current diff.
 
 #### Limitations
 
@@ -287,7 +307,7 @@ vim.keymap.set("n", "<leader>glR", gitlab.revoke)
 vim.keymap.set("n", "<leader>glc", gitlab.create_comment)
 vim.keymap.set("v", "<leader>glc", gitlab.create_multiline_comment)
 vim.keymap.set("v", "<leader>glC", gitlab.create_comment_suggestion)
-vim.keymap.set("n", "<leader>glj", gitlab.jump_to_discussion_tree_from_diagnostic)
+vim.keymap.set("n", "<leader>glm", gitlab.move_to_discussion_tree_from_diagnostic)
 vim.keymap.set("n", "<leader>gln", gitlab.create_note)
 vim.keymap.set("n", "<leader>gld", gitlab.toggle_discussions)
 vim.keymap.set("n", "<leader>glaa", gitlab.add_assignee)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ require("gitlab").setup({
     texthl = nil,
     culhl = nil,
     numhl = nil,
+    priority = 20,
+    helper_signs = {
+      -- For multiline comments the helper signs are used to indicate the whole context
+      -- Priority of helper signs is lower than the main sign (-1).
+      enabled = true,
+      start = "↑",
+      mid = "|",
+      ["end"] = "↓",
+    },
   },
   discussion_diagnostics = {
     -- If you want to customize diagnostics for discussions you can make special config
@@ -212,6 +221,10 @@ By default when reviewing files you will see signs and diagnostics ( if enabled 
 ```lua
 require("gitlab").jump_to_discussion_tree_from_diagnostic()
 ```
+
+#### Limitations
+
+When checking multiline diagnostic the cursor must be on the "main" line of diagnostic -> where the `discussion_sign.text` is shown otherwise `vim.diagnostic.show` and `jump_to_discussion_tree_from_diagnostic` will not work.
 
 ### Uploading Files
 

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -33,8 +33,20 @@ func ExtractGitInfo(getProjectRemoteUrl func() (string, error), getCurrentBranch
 		return GitProjectInfo{}, fmt.Errorf("Could not get project Url: %v", err)
 	}
 
-  // play with regex at: https://regex101.com/r/P2jSGh/1
-	re := regexp.MustCompile(`(?:^git@.+:|^https?:\/\/.+?[^\/:]\/)(.+)\/([^\/]+)\.git$`)
+	// play with regex at: https://regex101.com/r/P2jSGh/1
+	/*
+	   This should match following formats:
+	       namespace: namespace, projectName: dummy-test-repo:
+	           https://gitlab.com/namespace/dummy-test-repo.git
+	           git@gitlab.com:namespace/dummy-test-repo.git
+	           ssh://git@gitlab.com/namespace/dummy-test-repo.git
+
+	       namespace: namespace/subnamespace, projectName: dummy-test-repo:
+	           ssh://git@gitlab.com/namespace/subnamespace/dummy-test-repo
+	           https://git@gitlab.com/namespace/subnamespace/dummy-test-repo.git
+	           git@git@gitlab.com:namespace/subnamespace/dummy-test-repo.git
+	*/
+	re := regexp.MustCompile(`(?:^https?:\/\/|^ssh:\/\/|^git@)(?:[^\/:]+)[\/:](.*)\/([^\/]+?)(?:\.git)?$`)
 	matches := re.FindStringSubmatch(url)
 	if len(matches) != 3 {
 		return GitProjectInfo{}, fmt.Errorf("Invalid Git URL format: %s", url)

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -146,6 +146,7 @@ M.confirm_create_comment = function(text, range, unlinked)
   job.run_job("/comment", "POST", body, function(data)
     u.notify("Comment created!", vim.log.levels.INFO)
     discussions.add_discussion({ data = data, unlinked = false })
+    discussions.refresh_discussion_data()
   end)
 end
 

--- a/lua/gitlab/actions/discussions.lua
+++ b/lua/gitlab/actions/discussions.lua
@@ -580,8 +580,8 @@ M.send_deletion = function(tree, unlinked)
         { M.unlinked_section.bufnr, M.unlinked_discussions, "No Notes (Unlinked Discussions) for this MR" },
       })
       M.switch_can_edit_bufs(false)
-    end)
-  end
+    end
+  end)
 end
 
 -- This function (settings.discussion_tree.edit_comment) will open the edit popup for the current comment in the discussion tree
@@ -709,7 +709,7 @@ M.rebuild_discussion_tree = function()
   M.set_tree_keymaps(discussion_tree, M.linked_section.bufnr, false)
   M.discussion_tree = discussion_tree
   M.switch_can_edit_bufs(false)
-  vim.api.nvim_buf_set_option(M.linked_section_bufnr, "filetype", "gitlab")
+  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.linked_section.bufnr })
 end
 
 M.rebuild_unlinked_discussion_tree = function()
@@ -721,7 +721,7 @@ M.rebuild_unlinked_discussion_tree = function()
   M.set_tree_keymaps(unlinked_discussion_tree, M.unlinked_section.bufnr, true)
   M.unlinked_discussion_tree = unlinked_discussion_tree
   M.switch_can_edit_bufs(false)
-  vim.api.nvim_buf_set_option(M.unlinked_section_bufnr, "filetype", "gitlab")
+  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.unlinked_section.bufnr })
 end
 
 M.switch_can_edit_bufs = function(bool)

--- a/lua/gitlab/actions/discussions.lua
+++ b/lua/gitlab/actions/discussions.lua
@@ -502,43 +502,17 @@ M.move_to_discussion_tree = function()
     vim.notify("No diagnostics for this line", vim.log.levels.WARN)
     return
   elseif #diagnostics > 1 then
-    local lines = {}
-    for _, diagnostic in pairs(diagnostics) do
-      table.insert(lines, Menu.item(diagnostic.user_data.header, { diagnostic = diagnostic }))
-    end
-    local menu = Menu({
-      relative = "cursor",
-      position = {
-        row = 1,
-        col = 0,
-      },
-      size = {
-        width = 50,
-      },
-      border = {
-        style = "single",
-        text = {
-          top = "Choose a discussion to jump to",
-          top_align = "center",
-        },
-      },
-      win_options = {
-        winhighlight = "Normal:Normal,FloatBorder:Normal",
-      },
-    }, {
-      lines = lines,
-      max_width = 50,
-      keymap = {
-        focus_next = state.settings.dialogue.focus_next,
-        focus_prev = state.settings.dialogue.focus_prev,
-        close = state.settings.dialogue.close,
-        submit = state.settings.dialogue.submit,
-      },
-      on_submit = function(item)
-        jump_after_menu_selection(item.diagnostic)
+    vim.ui.select(diagnostics, {
+      prompt = "Choose discussion to jump to",
+      format_item = function(diagnostic)
+        return diagnostic.message
       end,
-    })
-    menu:mount()
+    }, function(diagnostic)
+      if not diagnostic then
+        return
+      end
+      jump_after_menu_selection(diagnostic)
+    end)
   else
     jump_after_menu_selection(diagnostics[1])
   end

--- a/lua/gitlab/actions/discussions.lua
+++ b/lua/gitlab/actions/discussions.lua
@@ -125,6 +125,9 @@ M.filter_discussions_for_signs_and_diagnostics = function()
     return
   end
   local file = reviewer.get_current_file()
+  if not file then
+    return
+  end
   local discussions = {}
   for _, discussion in ipairs(M.discussions) do
     local first_note = discussion.notes[1]

--- a/lua/gitlab/actions/discussions.lua
+++ b/lua/gitlab/actions/discussions.lua
@@ -724,8 +724,7 @@ M.add_discussion = function(arg)
       M.unlinked_discussions = {}
     end
     table.insert(M.unlinked_discussions, 1, discussion)
-    local bufinfo = vim.fn.getbufinfo(M.unlinked_section.bufnr)
-    if u.table_size(bufinfo) ~= 0 then
+    if M.unlinked_section ~= nil then
       M.rebuild_unlinked_discussion_tree()
     end
     return
@@ -734,8 +733,7 @@ M.add_discussion = function(arg)
     M.discussions = {}
   end
   table.insert(M.discussions, 1, discussion)
-  local bufinfo = vim.fn.getbufinfo(M.unlinked_section.bufnr)
-  if u.table_size(bufinfo) ~= 0 then
+  if M.linked_section ~= nil then
     M.rebuild_discussion_tree()
   end
 end

--- a/lua/gitlab/actions/discussions.lua
+++ b/lua/gitlab/actions/discussions.lua
@@ -19,35 +19,6 @@ local discussion_helper_sign_mid = "gitlab_discussion_helper_mid"
 local discussion_helper_sign_end = "gitlab_discussion_helper_end"
 local diagnostics_namespace = vim.api.nvim_create_namespace(discussion_sign_name)
 
-vim.fn.sign_define(discussion_sign_name, {
-  text = state.settings.discussion_sign.text,
-  linehl = state.settings.discussion_sign.linehl,
-  texthl = state.settings.discussion_sign.texthl,
-  culhl = state.settings.discussion_sign.culhl,
-  numhl = state.settings.discussion_sign.numhl,
-})
-vim.fn.sign_define(discussion_helper_sign_start, {
-  text = state.settings.discussion_sign.helper_signs.start,
-  linehl = state.settings.discussion_sign.linehl,
-  texthl = state.settings.discussion_sign.texthl,
-  culhl = state.settings.discussion_sign.culhl,
-  numhl = state.settings.discussion_sign.numhl,
-})
-vim.fn.sign_define(discussion_helper_sign_mid, {
-  text = state.settings.discussion_sign.helper_signs.mid,
-  linehl = state.settings.discussion_sign.linehl,
-  texthl = state.settings.discussion_sign.texthl,
-  culhl = state.settings.discussion_sign.culhl,
-  numhl = state.settings.discussion_sign.numhl,
-})
-vim.fn.sign_define(discussion_helper_sign_end, {
-  text = state.settings.discussion_sign.helper_signs["end"],
-  linehl = state.settings.discussion_sign.linehl,
-  texthl = state.settings.discussion_sign.texthl,
-  culhl = state.settings.discussion_sign.culhl,
-  numhl = state.settings.discussion_sign.numhl,
-})
-
 local M = {
   layout_visible = false,
   layout = nil,
@@ -147,98 +118,129 @@ local function _parse_line_code(line_code)
   return tonumber(old_line), tonumber(new_line)
 end
 
+---Filter all discussions which are relevant for currently visible signs and diagnostscs.
+---@return Discussion[]?
+M.filter_discussions_for_signs_and_diagnostics = function()
+  if type(M.discussions) ~= "table" then
+    return
+  end
+  local file = reviewer.get_current_file()
+  local discussions = {}
+  for _, discussion in ipairs(M.discussions) do
+    local first_note = discussion.notes[1]
+    if
+      type(first_note.position) == "table"
+      and (first_note.position.new_path == file or first_note.position.old_path == file)
+    then
+      if
+        state.settings.discussion_sign_and_diagnostic.skip_resolved_discussion
+        and first_note.resolvable
+        and first_note.resolved
+      then
+        --Skip resolved discussions
+      elseif
+        state.settings.discussion_sign_and_diagnostic.skip_old_revision_discussion
+        and first_note.position.base_sha ~= state.MR_REVISIONS[1].base_sha
+      then
+        --Skip discussions from old revisions
+      else
+        table.insert(discussions, discussion)
+      end
+    end
+  end
+  return discussions
+end
+
 ---Refresh the discussion signs for currently loaded file in reviewer For convinience we use same
 ---string for sign name and sign group ( currently there is only one sign needed)
 M.refresh_signs = function()
-  local file = reviewer.get_current_file()
+  local diagnostics = M.filter_discussions_for_signs_and_diagnostics()
+  if diagnostics == nil then
+    vim.diagnostic.reset(diagnostics_namespace)
+    return
+  end
+
   local new_signs = {}
   local old_signs = {}
-  if type(M.discussions) == "table" then
-    for _, discussion in ipairs(M.discussions) do
-      local first_note = discussion.notes[1]
-      if
-        type(first_note.position) == "table"
-        and (first_note.position.new_path == file or first_note.position.old_path == file)
-      then
-        local base_sign = {
-          name = discussion_sign_name,
-          group = discussion_sign_name,
-          priority = state.settings.discussion_sign.priority,
-        }
-        local base_helper_sign = {
-          name = discussion_sign_name,
-          group = discussion_sign_name,
-          priority = state.settings.discussion_sign.priority - 1,
-        }
-        if first_note.position.line_range ~= nil then
-          local start_old_line, start_new_line = _parse_line_code(first_note.position.line_range.start.line_code)
-          local end_old_line, end_new_line = _parse_line_code(first_note.position.line_range["end"].line_code)
-          local discussion_line, start_line, end_line
-          if first_note.position.line_range.start.type == "new" then
-            table.insert(
-              new_signs,
-              vim.tbl_deep_extend("force", {
-                id = first_note.id,
-                lnum = first_note.position.new_line,
-              }, base_sign)
-            )
-            discussion_line = first_note.position.new_line
-            start_line = start_new_line
-            end_line = end_new_line
-          elseif first_note.position.line_range.start.type == "old" then
-            table.insert(
-              old_signs,
-              vim.tbl_deep_extend("force", {
-                id = first_note.id,
-                lnum = first_note.position.old_line,
-              }, base_sign)
-            )
-            discussion_line = first_note.position.old_line
-            start_line = start_old_line
-            end_line = end_old_line
-          end
-          -- Helper signs does not have specific ids currently.
-          if state.settings.discussion_sign.helper_signs.enabled then
-            local helper_signs = {}
-            if start_line > end_line then
-              start_line, end_line = end_line, start_line
-            end
-            for i = start_line, end_line do
-              if i ~= discussion_line then
-                local sign_name
-                if i == start_line then
-                  sign_name = discussion_helper_sign_start
-                elseif i == end_line then
-                  sign_name = discussion_helper_sign_end
-                else
-                  sign_name = discussion_helper_sign_mid
-                end
-                table.insert(
-                  helper_signs,
-                  vim.tbl_deep_extend("keep", {
-                    name = sign_name,
-                    lnum = i,
-                  }, base_helper_sign)
-                )
-              end
-            end
-            if first_note.position.line_range.start.type == "new" then
-              vim.list_extend(new_signs, helper_signs)
-            elseif first_note.position.line_range.start.type == "old" then
-              vim.list_extend(old_signs, helper_signs)
-            end
-          end
-        else
-          local sign = vim.tbl_deep_extend("force", {
+  for _, discussion in ipairs(diagnostics) do
+    local first_note = discussion.notes[1]
+    local base_sign = {
+      name = discussion_sign_name,
+      group = discussion_sign_name,
+      priority = state.settings.discussion_sign.priority,
+    }
+    local base_helper_sign = {
+      name = discussion_sign_name,
+      group = discussion_sign_name,
+      priority = state.settings.discussion_sign.priority - 1,
+    }
+    if first_note.position.line_range ~= nil then
+      local start_old_line, start_new_line = _parse_line_code(first_note.position.line_range.start.line_code)
+      local end_old_line, end_new_line = _parse_line_code(first_note.position.line_range["end"].line_code)
+      local discussion_line, start_line, end_line
+      if first_note.position.line_range.start.type == "new" then
+        table.insert(
+          new_signs,
+          vim.tbl_deep_extend("force", {
             id = first_note.id,
+            lnum = first_note.position.new_line,
           }, base_sign)
-          if first_note.position.new_line ~= nil then
-            table.insert(new_signs, vim.tbl_deep_extend("force", { lnum = first_note.position.new_line }, sign))
-          end
-          if first_note.position.old_line ~= nil then
-            table.insert(old_signs, vim.tbl_deep_extend("force", { lnum = first_note.position.old_line }, sign))
+        )
+        discussion_line = first_note.position.new_line
+        start_line = start_new_line
+        end_line = end_new_line
+      elseif first_note.position.line_range.start.type == "old" then
+        table.insert(
+          old_signs,
+          vim.tbl_deep_extend("force", {
+            id = first_note.id,
+            lnum = first_note.position.old_line,
+          }, base_sign)
+        )
+        discussion_line = first_note.position.old_line
+        start_line = start_old_line
+        end_line = end_old_line
+      end
+      -- Helper signs does not have specific ids currently.
+      if state.settings.discussion_sign.helper_signs.enabled then
+        local helper_signs = {}
+        if start_line > end_line then
+          start_line, end_line = end_line, start_line
+        end
+        for i = start_line, end_line do
+          if i ~= discussion_line then
+            local sign_name
+            if i == start_line then
+              sign_name = discussion_helper_sign_start
+            elseif i == end_line then
+              sign_name = discussion_helper_sign_end
+            else
+              sign_name = discussion_helper_sign_mid
+            end
+            table.insert(
+              helper_signs,
+              vim.tbl_deep_extend("keep", {
+                name = sign_name,
+                lnum = i,
+              }, base_helper_sign)
+            )
           end
         end
+        if first_note.position.line_range.start.type == "new" then
+          vim.list_extend(new_signs, helper_signs)
+        elseif first_note.position.line_range.start.type == "old" then
+          vim.list_extend(old_signs, helper_signs)
+        end
+      end
+    else
+      local sign = vim.tbl_deep_extend("force", {
+        id = first_note.id,
+      }, base_sign)
+      if first_note.position.new_line ~= nil then
+        table.insert(new_signs, vim.tbl_deep_extend("force", { lnum = first_note.position.new_line }, sign))
+      end
+      if first_note.position.old_line ~= nil then
+        table.insert(old_signs, vim.tbl_deep_extend("force", { lnum = first_note.position.old_line }, sign))
       end
     end
   end
@@ -251,87 +253,82 @@ end
 M.refresh_diagnostics = function()
   -- Keep in mind that diagnostic line numbers use 0-based indexing while line numbers use
   -- 1-based indexing
-  local file = reviewer.get_current_file()
-  local new_diagnostics = {}
-  local old_diagnostics = {}
-  if type(M.discussions) ~= "table" then
+  local diagnostics = M.filter_discussions_for_signs_and_diagnostics()
+  if diagnostics == nil then
     vim.diagnostic.reset(diagnostics_namespace)
     return
   end
 
-  for _, discussion in ipairs(M.discussions) do
+  local new_diagnostics = {}
+  local old_diagnostics = {}
+  for _, discussion in ipairs(diagnostics) do
     local first_note = discussion.notes[1]
-    if
-      type(first_note.position) == "table"
-      and (first_note.position.new_path == file or first_note.position.old_path == file)
-    then
-      local message = ""
-      for _, note in ipairs(discussion.notes) do
-        message = message .. M.build_note_header(note) .. "\n" .. note.body .. "\n"
-      end
+    local message = ""
+    for _, note in ipairs(discussion.notes) do
+      message = message .. M.build_note_header(note) .. "\n" .. note.body .. "\n"
+    end
 
-      local diagnostic = {
-        message = message,
-        col = 0,
-        severity = state.settings.discussion_diagnostics.severity,
-        user_data = { discussion_id = discussion.id, header = M.build_note_header(discussion.notes[1]) },
-        source = "gitlab",
-        code = state.settings.discussion_diagnostics.code,
-      }
-      if first_note.position.line_range ~= nil then
-        -- Diagnostics for line range discussions are tricky - you need to set lnum to
-        -- line number equal to note.position.new_line or note.position.old_line because that is
-        -- only line where you can trigger the diagnostic show. This also need to be in sinc
-        -- with the sign placement.
-        local start_old_line, start_new_line = _parse_line_code(first_note.position.line_range.start.line_code)
-        local end_old_line, end_new_line = _parse_line_code(first_note.position.line_range["end"].line_code)
-        if first_note.position.line_range.start.type == "new" then
-          local new_diagnostic
-          if first_note.position.new_line == start_new_line then
-            new_diagnostic = {
-              lnum = start_new_line - 1,
-              end_lnum = end_new_line - 1,
-            }
-          else
-            new_diagnostic = {
-              lnum = end_new_line - 1,
-              end_lnum = start_new_line - 1,
-            }
-          end
-          new_diagnostic = vim.tbl_deep_extend("force", new_diagnostic, diagnostic)
-          table.insert(new_diagnostics, new_diagnostic)
-        elseif first_note.position.line_range.start.type == "old" then
-          local old_diagnostic
-          if first_note.position.old_line == start_old_line then
-            old_diagnostic = {
-              lnum = start_old_line - 1,
-              end_lnum = end_old_line - 1,
-            }
-          else
-            old_diagnostic = {
-              lnum = end_old_line - 1,
-              end_lnum = start_old_line - 1,
-            }
-          end
-          old_diagnostic = vim.tbl_deep_extend("force", old_diagnostic, diagnostic)
-          table.insert(old_diagnostics, old_diagnostic)
-        end
-      else
-        -- Diagnostics for single line discussions.
-        if first_note.position.new_line ~= nil then
-          local new_diagnostic = {
-            lnum = first_note.position.new_line - 1,
+    local diagnostic = {
+      message = message,
+      col = 0,
+      severity = state.settings.discussion_diagnostic.severity,
+      user_data = { discussion_id = discussion.id, header = M.build_note_header(discussion.notes[1]) },
+      source = "gitlab",
+      code = state.settings.discussion_diagnostic.code,
+    }
+    if first_note.position.line_range ~= nil then
+      -- Diagnostics for line range discussions are tricky - you need to set lnum to
+      -- line number equal to note.position.new_line or note.position.old_line because that is
+      -- only line where you can trigger the diagnostic show. This also need to be in sinc
+      -- with the sign placement.
+      local start_old_line, start_new_line = _parse_line_code(first_note.position.line_range.start.line_code)
+      local end_old_line, end_new_line = _parse_line_code(first_note.position.line_range["end"].line_code)
+      if first_note.position.line_range.start.type == "new" then
+        local new_diagnostic
+        if first_note.position.new_line == start_new_line then
+          new_diagnostic = {
+            lnum = start_new_line - 1,
+            end_lnum = end_new_line - 1,
           }
-          new_diagnostic = vim.tbl_deep_extend("force", new_diagnostic, diagnostic)
-          table.insert(new_diagnostics, new_diagnostic)
-        end
-        if first_note.position.old_line ~= nil then
-          local old_diagnostic = {
-            lnum = first_note.position.old_line - 1,
+        else
+          new_diagnostic = {
+            lnum = end_new_line - 1,
+            end_lnum = start_new_line - 1,
           }
-          old_diagnostic = vim.tbl_deep_extend("force", old_diagnostic, diagnostic)
-          table.insert(old_diagnostics, old_diagnostic)
         end
+        new_diagnostic = vim.tbl_deep_extend("force", new_diagnostic, diagnostic)
+        table.insert(new_diagnostics, new_diagnostic)
+      elseif first_note.position.line_range.start.type == "old" then
+        local old_diagnostic
+        if first_note.position.old_line == start_old_line then
+          old_diagnostic = {
+            lnum = start_old_line - 1,
+            end_lnum = end_old_line - 1,
+          }
+        else
+          old_diagnostic = {
+            lnum = end_old_line - 1,
+            end_lnum = start_old_line - 1,
+          }
+        end
+        old_diagnostic = vim.tbl_deep_extend("force", old_diagnostic, diagnostic)
+        table.insert(old_diagnostics, old_diagnostic)
+      end
+    else
+      -- Diagnostics for single line discussions.
+      if first_note.position.new_line ~= nil then
+        local new_diagnostic = {
+          lnum = first_note.position.new_line - 1,
+        }
+        new_diagnostic = vim.tbl_deep_extend("force", new_diagnostic, diagnostic)
+        table.insert(new_diagnostics, new_diagnostic)
+      end
+      if first_note.position.old_line ~= nil then
+        local old_diagnostic = {
+          lnum = first_note.position.old_line - 1,
+        }
+        old_diagnostic = vim.tbl_deep_extend("force", old_diagnostic, diagnostic)
+        table.insert(old_diagnostics, old_diagnostic)
       end
     end
   end
@@ -341,13 +338,13 @@ M.refresh_diagnostics = function()
     diagnostics_namespace,
     new_diagnostics,
     "new",
-    state.settings.discussion_diagnostics.display_opts
+    state.settings.discussion_diagnostic.display_opts
   )
   reviewer.set_diagnostics(
     diagnostics_namespace,
     old_diagnostics,
     "old",
-    state.settings.discussion_diagnostics.display_opts
+    state.settings.discussion_diagnostic.display_opts
   )
 end
 
@@ -357,16 +354,56 @@ M.refresh_discussion_data = function()
     if state.settings.discussion_sign.enabled then
       M.refresh_signs()
     end
-    if state.settings.discussion_diagnostics.enabled then
+    if state.settings.discussion_diagnostic.enabled then
       M.refresh_diagnostics()
     end
   end)
+end
+
+---Define signs for discussions if not already defined
+M.setup_signs = function()
+  local discussion_sign = state.settings.discussion_sign
+  local signs = {
+    [discussion_sign_name] = discussion_sign.text,
+    [discussion_helper_sign_start] = discussion_sign.helper_signs.start,
+    [discussion_helper_sign_mid] = discussion_sign.helper_signs.mid,
+    [discussion_helper_sign_end] = discussion_sign.helper_signs["end"],
+  }
+  for sign_name, sign_text in pairs(signs) do
+    if #vim.fn.sign_getdefined(sign_name) == 0 then
+      vim.fn.sign_define(sign_name, {
+        text = sign_text,
+        linehl = discussion_sign.linehl,
+        texthl = discussion_sign.texthl,
+        culhl = discussion_sign.culhl,
+        numhl = discussion_sign.numhl,
+      })
+    end
+  end
+end
+
+---Initialize everything for discussions like setup of signs, callbacks for reviewer, etc.
+M.initialize_discussions = function()
+  M.setup_signs()
+  M.setup_refresh_discussion_data_callback()
+  M.setup_leave_reviewer_callback()
 end
 
 ---Setup callback to refresh discussion data, discussion signs and diagnostics whenever the
 ---reviewed file changes.
 M.setup_refresh_discussion_data_callback = function()
   reviewer.set_callback_for_file_changed(M.refresh_discussion_data)
+end
+
+---Clear all signs and diagnostics
+M.clear_signs_and_discussions = function()
+  vim.fn.sign_unplace(discussion_sign_name)
+  vim.diagnostic.reset(diagnostics_namespace)
+end
+
+---Setup callback to clear signs and diagnostics whenever reviewer is left.
+M.setup_leave_reviewer_callback = function()
+  reviewer.set_callback_for_reviewer_leave(M.clear_signs_and_discussions)
 end
 
 M.refresh_discussion_tree = function()
@@ -426,8 +463,8 @@ M.toggle = function(callback)
   end)
 end
 
----Jump to the discussion tree at the discussion from diagnostic on current line.
-M.jump_to_discussion_tree = function()
+---Move to the discussion tree at the discussion from diagnostic on current line.
+M.move_to_discussion_tree = function()
   local current_line = vim.api.nvim_win_get_cursor(0)[1]
   local diagnostics = vim.diagnostic.get(0, { namespace = diagnostics_namespace, lnum = current_line - 1 })
 

--- a/lua/gitlab/actions/discussions.lua
+++ b/lua/gitlab/actions/discussions.lua
@@ -133,17 +133,18 @@ M.filter_discussions_for_signs_and_diagnostics = function()
       and (first_note.position.new_path == file or first_note.position.old_path == file)
     then
       if
-        state.settings.discussion_sign_and_diagnostic.skip_resolved_discussion
-        and first_note.resolvable
-        and first_note.resolved
-      then
         --Skip resolved discussions
-      elseif
-        state.settings.discussion_sign_and_diagnostic.skip_old_revision_discussion
-        and first_note.position.base_sha ~= state.MR_REVISIONS[1].base_sha
-      then
+        not (
+          state.settings.discussion_sign_and_diagnostic.skip_resolved_discussion
+          and first_note.resolvable
+          and first_note.resolved
+        )
         --Skip discussions from old revisions
-      else
+        and not (
+          state.settings.discussion_sign_and_diagnostic.skip_old_revision_discussion
+          and first_note.position.base_sha ~= state.MR_REVISIONS[1].base_sha
+        )
+      then
         table.insert(discussions, discussion)
       end
     end

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -23,8 +23,8 @@ return {
     server.build() -- Builds the Go binary if it doesn't exist
     state.merge_settings(args) -- Sets keymaps and other settings from setup function
     require("gitlab.colors") -- Sets colors
-    reviewer.init()
-    discussions.setup_refresh_discussion_data_callback() -- place signs / diagnostics for discussions in reviewer
+    reviewer.init() -- Picks and initializes reviewer (default is Delta)
+    discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
     u.has_reviewer(args.reviewer or "delta")
   end,
   -- Global Actions 🌎
@@ -38,9 +38,9 @@ return {
   create_comment = async.sequence({ info, revisions }, comment.create_comment),
   create_multiline_comment = async.sequence({ info, revisions }, comment.create_multiline_comment),
   create_comment_suggestion = async.sequence({ info, revisions }, comment.create_comment_suggestion),
-  jump_to_discussion_tree_from_diagnostic = async.sequence({}, discussions.jump_to_discussion_tree),
+  move_to_discussion_tree_from_diagnostic = async.sequence({}, discussions.move_to_discussion_tree),
   create_note = async.sequence({ info }, comment.create_note),
-  review = async.sequence({ u.merge(info, { refresh = true }) }, function()
+  review = async.sequence({ u.merge(info, { refresh = true }), revisions }, function()
     reviewer.open()
   end),
   pipeline = async.sequence({ info }, pipeline.open),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -38,6 +38,7 @@ return {
   create_comment = async.sequence({ info, revisions }, comment.create_comment),
   create_multiline_comment = async.sequence({ info, revisions }, comment.create_multiline_comment),
   create_comment_suggestion = async.sequence({ info, revisions }, comment.create_comment_suggestion),
+  jump_to_discussion_tree_from_diagnostic = async.sequence({}, discussions.jump_to_discussion_tree),
   create_note = async.sequence({ info }, comment.create_note),
   review = async.sequence({ u.merge(info, { refresh = true }) }, function()
     reviewer.open()

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -23,7 +23,7 @@ return {
     server.build() -- Builds the Go binary if it doesn't exist
     state.merge_settings(args) -- Sets keymaps and other settings from setup function
     require("gitlab.colors") -- Sets colors
-    reviewer.init() -- Picks and initializes reviewer (default is Delta)
+    reviewer.init()
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
   end,
   -- Global Actions 🌎

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -25,7 +25,6 @@ return {
     require("gitlab.colors") -- Sets colors
     reviewer.init() -- Picks and initializes reviewer (default is Delta)
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
-    u.has_reviewer(args.reviewer or "delta")
   end,
   -- Global Actions 🌎
   summary = async.sequence({ info }, summary.summary),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -24,6 +24,8 @@ return {
     state.merge_settings(args) -- Sets keymaps and other settings from setup function
     require("gitlab.colors") -- Sets colors
     reviewer.init()
+    discussions.setup_refresh_discussion_data_callback() -- place signs / diagnostics for discussions in reviewer
+    u.has_reviewer(args.reviewer or "delta")
   end,
   -- Global Actions 🌎
   summary = async.sequence({ info }, summary.summary),

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -192,11 +192,23 @@ end
 ---Diffview exposes events which can be used to setup autocommands.
 ---@param callback fun(opts: table) - for more information about opts see callback in :h nvim_create_autocmd
 M.set_callback_for_file_changed = function(callback)
-  local group = vim.api.nvim_create_augroup("gitlab.diffview.autocommand", {})
+  local group = vim.api.nvim_create_augroup("gitlab.diffview.autocommand.file_changed", {})
   vim.api.nvim_create_autocmd("User", {
-    pattern = "DiffviewDiffBufWinEnter",
+    pattern = { "DiffviewDiffBufWinEnter", "DiffviewViewEnter" },
     group = group,
     callback = callback,
   })
 end
+
+---Diffview exposes events which can be used to setup autocommands.
+---@param callback fun(opts: table) - for more information about opts see callback in :h nvim_create_autocmd
+M.set_callback_for_reviewer_leave = function(callback)
+  local group = vim.api.nvim_create_augroup("gitlab.diffview.autocommand.leave", {})
+  vim.api.nvim_create_autocmd("User", {
+    pattern = { "DiffviewViewLeave", "DiffviewViewClosed" },
+    group = group,
+    callback = callback,
+  })
+end
+
 return M

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -180,9 +180,9 @@ end
 ---@param opts table? see :h vim.diagnostic.set
 M.set_diagnostics = function(namespace, diagnostics, type, opts)
   local view = diffview_lib.get_current_view()
-  if type == "new" then
+  if type == "new" and view.cur_layout.b.file.bufnr then
     vim.diagnostic.set(namespace, view.cur_layout.b.file.bufnr, diagnostics, opts)
-  elseif type == "old" then
+  elseif type == "old" and view.cur_layout.a.file.bufnr then
     vim.diagnostic.set(namespace, view.cur_layout.a.file.bufnr, diagnostics, opts)
   else
     vim.notify("Unknown diagnostic type", vim.log.levels.ERROR)

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -12,6 +12,17 @@ local M = {
 M.open = function()
   vim.api.nvim_command(string.format("DiffviewOpen %s", state.INFO.target_branch))
   M.tabnr = vim.api.nvim_get_current_tabpage()
+  local group = vim.api.nvim_create_augroup("gitlab.diffview.autocommand.close", {})
+  vim.api.nvim_create_autocmd("User", {
+    pattern = { "DiffviewViewClosed" },
+    group = group,
+    callback = function()
+      --Check if our diffview tab was closed
+      if vim.api.nvim_tabpage_is_valid(M.tabnr) then
+        M.tabnr = nil
+      end
+    end,
+  })
 end
 
 M.jump = function(file_name, new_line, old_line)
@@ -196,7 +207,11 @@ M.set_callback_for_file_changed = function(callback)
   vim.api.nvim_create_autocmd("User", {
     pattern = { "DiffviewDiffBufWinEnter", "DiffviewViewEnter" },
     group = group,
-    callback = callback,
+    callback = function(...)
+      if M.tabnr == vim.api.nvim_get_current_tabpage() then
+        callback(...)
+      end
+    end,
   })
 end
 
@@ -207,7 +222,11 @@ M.set_callback_for_reviewer_leave = function(callback)
   vim.api.nvim_create_autocmd("User", {
     pattern = { "DiffviewViewLeave", "DiffviewViewClosed" },
     group = group,
-    callback = callback,
+    callback = function(...)
+      if M.tabnr == vim.api.nvim_get_current_tabpage() then
+        callback(...)
+      end
+    end,
   })
 end
 

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -157,19 +157,20 @@ end
 
 ---Place a sign in currently reviewed file. Use new line for identifing lines after changes, old
 ---line for identifing lines before changes and both if line was not changed.
----@param id number id of sign
----@param sign_name string sign to place
----@param group string group of sign
----@param new_line number? line number after change
----@param old_line number? line number before change
-M.place_sign = function(id, sign_name, group, new_line, old_line)
+---@param signs table table of signs. See :h sign_placelist
+---@param type string "new" if diagnostic should be in file after changes else "old"
+M.place_sign = function(signs, type)
   local view = diffview_lib.get_current_view()
-  if new_line ~= nil then
-    vim.fn.sign_place(id, group, sign_name, view.cur_layout.b.file.bufnr, { lnum = new_line })
+  if type == "new" then
+    for _, sign in ipairs(signs) do
+      sign.buffer = view.cur_layout.b.file.bufnr
+    end
+  elseif type == "old" then
+    for _, sign in ipairs(signs) do
+      sign.buffer = view.cur_layout.a.file.bufnr
+    end
   end
-  if old_line ~= nil then
-    vim.fn.sign_place(id, group, sign_name, view.cur_layout.a.file.bufnr, { lnum = old_line })
-  end
+  vim.fn.sign_placelist(signs)
 end
 
 ---Set diagnostics in currently reviewed file.

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -160,15 +160,15 @@ end
 ---@param id number id of sign
 ---@param sign_name string sign to place
 ---@param group string group of sign
----@param new_line number line number after change
----@param old_line number line number before change
+---@param new_line number? line number after change
+---@param old_line number? line number before change
 M.place_sign = function(id, sign_name, group, new_line, old_line)
   local view = diffview_lib.get_current_view()
   if new_line ~= nil then
     vim.fn.sign_place(id, group, sign_name, view.cur_layout.b.file.bufnr, { lnum = new_line })
   end
   if old_line ~= nil then
-    vim.fn.sign_place(id, group, sign_name, view.cur_layout.a.file.bufnr, { lnum = new_line })
+    vim.fn.sign_place(id, group, sign_name, view.cur_layout.a.file.bufnr, { lnum = old_line })
   end
 end
 

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -163,7 +163,11 @@ end
 
 ---Get currently shown file
 M.get_current_file = function()
-  return diffview_lib.get_current_view().panel.cur_file.path
+  local view = diffview_lib.get_current_view()
+  if not view then
+    return
+  end
+  return view.panel.cur_file.path
 end
 
 ---Place a sign in currently reviewed file. Use new line for identifing lines after changes, old
@@ -172,6 +176,9 @@ end
 ---@param type string "new" if diagnostic should be in file after changes else "old"
 M.place_sign = function(signs, type)
   local view = diffview_lib.get_current_view()
+  if not view then
+    return
+  end
   if type == "new" then
     for _, sign in ipairs(signs) do
       sign.buffer = view.cur_layout.b.file.bufnr
@@ -191,6 +198,9 @@ end
 ---@param opts table? see :h vim.diagnostic.set
 M.set_diagnostics = function(namespace, diagnostics, type, opts)
   local view = diffview_lib.get_current_view()
+  if not view then
+    return
+  end
   if type == "new" and view.cur_layout.b.file.bufnr then
     vim.diagnostic.set(namespace, view.cur_layout.b.file.bufnr, diagnostics, opts)
   elseif type == "old" and view.cur_layout.a.file.bufnr then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -42,7 +42,7 @@ M.init = function()
 
   M.place_sign = reviewer.place_sign
   -- Places a sign on the line for currently reviewed file.
-  -- Prameters:
+  -- Parameters:
   --   • {id}    The sign id
   --   • {sign}  The sign to place
   --   • {group} The sign group to place on
@@ -54,9 +54,14 @@ M.init = function()
   -- Parameters:
   --   • {callback}  The callback to call
 
+  M.set_callback_for_reviewer_leave = reviewer.set_callback_for_reviewer_leave
+  -- Call callback whenever the reviewer is left
+  -- Parameters:
+  --   • {callback}  The callback to call
+
   M.set_diagnostics = reviewer.set_diagnostics
   -- Set diagnostics for currently reviewed file
-  -- Prameters:
+  -- Parameters:
   --   • {namespace}    The namespace for diagnostics
   --   • {diagnostics}  The diagnostics to set
   --   • {type}         "new" if diagnostic should be in file after changes else "old"

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -36,6 +36,31 @@ M.init = function()
 
   M.get_lines = reviewer.get_lines
   -- Returns the content of the file in the current location in the reviewer window
+
+  M.get_current_file = reviewer.get_current_file
+  -- Get currently loaded file
+
+  M.place_sign = reviewer.place_sign
+  -- Places a sign on the line for currently reviewed file.
+  -- Prameters:
+  --   • {id}    The sign id
+  --   • {sign}  The sign to place
+  --   • {group} The sign group to place on
+  --   • {new_line}  The line to place the sign on
+  --   • {old_line} The buffer number to place the sign on
+
+  M.set_callback_for_file_changed = reviewer.set_callback_for_file_changed
+  -- Call callback whenever the file changes
+  -- Parameters:
+  --   • {callback}  The callback to call
+
+  M.set_diagnostics = reviewer.set_diagnostics
+  -- Set diagnostics for currently reviewed file
+  -- Prameters:
+  --   • {namespace}    The namespace for diagnostics
+  --   • {diagnostics}  The diagnostics to set
+  --   • {type}         "new" if diagnostic should be in file after changes else "old"
+  --   • {opts}         see opts in :h vim.diagnostic.set
 end
 
 return M

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -34,12 +34,22 @@ M.settings = {
     unresolved = "",
   },
   discussion_sign = {
+    -- See :h sign_define for details about sign configuration.
     enabled = true,
     text = "💬",
     linehl = nil,
     texthl = nil,
     culhl = nil,
     numhl = nil,
+    priority = 20,
+    helper_signs = {
+      -- For multiline comments the helper signs are used to indicate the whole context
+      -- Priority of helper signs is lower than the main sign (-1).
+      enabled = true,
+      start = "↑",
+      mid = "|",
+      ["end"] = "↓",
+    },
   },
   discussion_diagnostics = {
     -- If you want to customize diagnostics for discussions you can make special config

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -42,8 +42,11 @@ M.settings = {
     numhl = nil,
   },
   discussion_diagnostics = {
+    -- If you want to customize diagnostics for discussions you can make special config
+    -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,
     severity = vim.diagnostic.severity.INFO,
+    code = nil, -- see :h diagnostic-structure
     display_opts = {}, -- see opts in vim.diagnostic.set
   },
   pipeline = {

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -61,7 +61,7 @@ M.settings = {
     enabled = true,
     severity = vim.diagnostic.severity.INFO,
     code = nil, -- see :h diagnostic-structure
-    display_opts = {}, -- see opts in vim.diagnostic.set
+    display_opts = {}, -- this is dirrectly used as opts in vim.diagnostic.set, see :h vim.diagnostic.config.
   },
   pipeline = {
     created = "",

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -33,6 +33,10 @@ M.settings = {
     resolved = "✓",
     unresolved = "",
   },
+  discussion_sign_and_diagnostic = {
+    skip_resolved_discussion = false,
+    skip_old_revision_discussion = false,
+  },
   discussion_sign = {
     -- See :h sign_define for details about sign configuration.
     enabled = true,
@@ -51,7 +55,7 @@ M.settings = {
       ["end"] = "↓",
     },
   },
-  discussion_diagnostics = {
+  discussion_diagnostic = {
     -- If you want to customize diagnostics for discussions you can make special config
     -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -33,6 +33,19 @@ M.settings = {
     resolved = "✓",
     unresolved = "",
   },
+  discussion_sign = {
+    enabled = true,
+    text = "💬",
+    linehl = nil,
+    texthl = nil,
+    culhl = nil,
+    numhl = nil,
+  },
+  discussion_diagnostics = {
+    enabled = true,
+    severity = vim.diagnostic.severity.INFO,
+    display_opts = {}, -- see opts in vim.diagnostic.set
+  },
   pipeline = {
     created = "",
     pending = "",


### PR DESCRIPTION
:wave: Hi,
this PR adds support for discussion sign and diagnostics. Diagnostics and signs are currently split on purpose ( even though the sign can be set also for diagnostic ) to have better control when multiline support will be added ( in this PR ). I will be testing this for few days to see if it works.

TODO:
* :heavy_check_mark: support multiline discussions for sign -> the idea is to have some main sign on line where the discussion is created and then other sign(s) ( maybe something like <--> but vertical ) if discussion is for multiple lines.
* :heavy_check_mark: support multiline discussions for diagnostics.
* currently the discussions are refreshed when file is switched / loaded in reviewer -> do we need periodic updates ? it would be maybe convenient :thinking: 
    * :heavy_check_mark:  ~~if we will have period updates maybe it is not great idea to always remove everything and set it again -> it is not hard to update to incremental updates.~~ this does not seem to be needed
* :heavy_check_mark: ~~actions for diagnostics / sign lines ( this may even be new PR )~~  for this PR I added function to jump to discussion tree where all other discussion actions are available. 
*  :heavy_check_mark: Maybe we should show sign and diagnostic for notes which match checksum ? Otherwise the discussion will have likely incorrect position :thinking: 