### PR TITLE
Fix highlight for usernames

### DIFF
--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -2,7 +2,7 @@ if filereadable($VIMRUNTIME . '/syntax/markdown.vim')
   source $VIMRUNTIME/syntax/markdown.vim
 endif
 
-syntax match Username "@\w\+"
+syntax match Username "@\I\+[\_\-\.]*\I\+"
 syntax match Date "\v\d+\s+\w+\s+ago"
 syntax match ChevronDown ""
 syntax match ChevronRight ""

--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -2,7 +2,7 @@ if filereadable($VIMRUNTIME . '/syntax/markdown.vim')
   source $VIMRUNTIME/syntax/markdown.vim
 endif
 
-syntax match Username "@\I\+[\_\-\.]*\I\+"
+syntax match Username "@\S*"
 syntax match Date "\v\d+\s+\w+\s+ago"
 syntax match ChevronDown ""
 syntax match ChevronRight ""

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -2,8 +2,8 @@ local Job = require("plenary.job")
 local M = {}
 
 M.get_colors_for_group = function(group)
-  local normal_fg = vim.fn.synIDattr(vim.fn.hlID(group), "fg")
-  local normal_bg = vim.fn.synIDattr(vim.fn.hlID(group), "bg")
+  local normal_fg = vim.fn.synIDattr(vim.fn.synIDtrans((vim.fn.hlID(group))), "fg")
+  local normal_bg = vim.fn.synIDattr(vim.fn.synIDtrans((vim.fn.hlID(group))), "bg")
   return { fg = normal_fg, bg = normal_bg }
 end
 


### PR DESCRIPTION
1. Fixed regex for username. Now it supports`_-.` and Unicode symbols like German letters.
![изображение](https://github.com/harrisoncramer/gitlab.nvim/assets/19637629/93cf5bdf-e3a3-4211-b9a2-fa1da0e565fb)
Here is example of usernames, which is valid, but didn't work before
```
@pötzsch 1 day ago 
@Aleksei.Sherchenkov 1 day ago 
@Aleksei-Sherchenkov 1 day ago 
@Aleksei_Sherchenkov-Second 1 day ago 
```

2. Fixed getting colors from HL groups. On my Mac in terminal, terminal using tmux and neovide it returned empty string. I took code from documentation of `vim.fn.hlID()`