### PR TITLE
Adds Tags Worfklow

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -1,0 +1,40 @@
+name: Tag + Bump Version
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build_tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Run action
+      id: taggerDryRun
+      uses: anothrNick/github-tag-action@1.64.0 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DRY_RUN: true
+    - name: Echo new tag
+      run: |
+        echo "The next tag version will be: ${{ steps.taggerDryRun.outputs.new_tag }}"
+    - name: Echo change version type
+      run: |
+        echo "The version increment was: ${{ steps.taggerDryRun.outputs.part }}"
+
+    # BUILD HERE, WILL ONLY EXECUTE IF PREVIOUS STEPS SUCCEEDED
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.64.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: patch
+        WITH_V: true
+        PRERELEASE: false


### PR DESCRIPTION
This MR adds the Github action that will automatically tag releases on every merge into main.

Since this is the start of our semantic versioning it is a #major bump to v1.