### PR TITLE
Fix: Allows you to open up gitlab.nvim even in nested directories

### DIFF
--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -141,6 +141,7 @@ M.see_logs = function()
     bufnr = vim.api.nvim_get_current_buf()
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
+    -- TODO: Fix for Windows
     local job_file_path = string.format("/tmp/gitlab.nvim.job-%d", j.id)
     vim.cmd("w! " .. job_file_path)
     vim.cmd.bd()

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -115,6 +115,8 @@ M.merge_settings = function(args)
     )
   end
 
+  M.settings.file_separator = (u.is_windows() and "\\" or "/")
+
   return true
 end
 
@@ -130,7 +132,15 @@ M.setPluginConfiguration = function()
   if M.initialized then
     return true
   end
-  local config_file_path = vim.fn.getcwd() .. "/.gitlab.nvim"
+
+  local base_path = vim.fn.trim(vim.fn.system({ "git", "rev-parse", "--show-toplevel" }))
+  if vim.v.shell_error ~= 0 then
+    u.notify(string.format("Could not get base directory: %s", base_path), vim.log.levels.ERROR)
+    return false
+  end
+
+  local config_file_path = base_path .. M.settings.file_separator .. ".gitlab.nvim"
+
   local config_file_content = u.read_file(config_file_path)
 
   local file_properties = {}


### PR DESCRIPTION
This MR is a #patch fix that ensures you can provide a `.gitlab.nvim` file at the root of the git project and open up the reviewer at any level of the project.