### PR TITLE
Re-worked regex to extract project's full path

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -80,9 +80,8 @@ func (c *Client) initGitlabClient() error {
 }
 
 /* This will fetch the project ID and merge request ID using the client */
-func (c *Client) initProjectSettings(remoteUrl string, namespace string, projectName string, branchName string) error {
+func (c *Client) initProjectSettings(remoteUrl string, idStr string, branchName string) error {
 
-	idStr := namespace + "/" + projectName
 	opt := gitlab.GetProjectOptions{}
 	project, _, err := c.git.Projects.GetProject(idStr, &opt)
 

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -19,7 +19,7 @@ func ExtractGitInfo() (string, string, string, error) {
 		return "", "", "", fmt.Errorf("Could not get project Url: %v", err)
 	}
 
-	re := regexp.MustCompile(`(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/*(.*)\.git`)
+	re := regexp.MustCompile(`(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/*(.*)`)
 	matches := re.FindStringSubmatch(url)
 	// matches[0] - url itself
 	// matches[1] - protocol (ssh, http(s))
@@ -27,24 +27,25 @@ func ExtractGitInfo() (string, string, string, error) {
 	// matches[3] - gitlab server name
 	// matches[4] - port
 	// matches[5] - project full path
-	// i.e. 'https://gitlab.organization.com/some.compex.path.to/project' will be parsed as
-	// matches[0] - https://gitlab.organization.com/some.compex.path.to/project
+	// i.e. 'https://gitlab.organization.com/some.compex.path.to/project.git' will be parsed as
+	// matches[0] - https://gitlab.organization.com/some.compex.path.to/project.git
 	// matches[1] - http://
 	// matches[2] -
 	// matches[3] - gitlab.organization.com
 	// matches[4] -
-	// matches[5] - some.complex.path.to/project
-
-	if matches[5] == "" {
+	// matches[5] - some.complex.path.to/project.git
+	if len(matches) != 6 || matches[5] == "" {
 		return "", "", "", fmt.Errorf("Failed to retrieve project path from Git URL: %s", url)
 	}
+
+	projectPath := strings.TrimSuffix(matches[5], ".git")
 
 	branch, err := getCurrentBranch()
 	if err != nil {
 		return "", "", "", fmt.Errorf("Failed to get current branch: %v", err)
 	}
 
-	return url, matches[5], branch, nil
+	return url, projectPath, branch, nil
 }
 
 /* Gets the current branch */

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -12,28 +12,27 @@ Extracts information about the current repository and returns
 it to the client for initialization. The current directory must be a valid
 Gitlab project and the branch must be a feature branch
 */
-func ExtractGitInfo() (string, string, string, string, error) {
+func ExtractGitInfo() (string, string, string, error) {
 
 	url, err := getProjectUrl()
 	if err != nil {
-		return "", "", "", "", fmt.Errorf("Could not get project Url: %v", err)
+		return "", "", "", fmt.Errorf("Could not get project Url: %v", err)
 	}
 
-	re := regexp.MustCompile(`(?:[:\/])([^\/]+)\/([^\/]+)\.git$`)
+	re := regexp.MustCompile(`(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/*(.*)\.git`)
 	matches := re.FindStringSubmatch(url)
-	if len(matches) != 3 {
-		return "", "", "", "", fmt.Errorf("Invalid Git URL format: %s", url)
+	if len(matches) > 5 {
+		return "", "", "", fmt.Errorf("Invalid Git URL format: %s", url)
 	}
 
-	namespace := matches[1]
-	projectName := matches[2]
+	projectPath := matches[5]
 
 	branch, err := getCurrentBranch()
 	if err != nil {
-		return "", "", "", "", fmt.Errorf("Failed to get current branch: %v", err)
+		return "", "", "", fmt.Errorf("Failed to get current branch: %v", err)
 	}
 
-	return url, namespace, projectName, branch, nil
+	return url, projectPath, branch, nil
 }
 
 /* Gets the current branch */

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -21,18 +21,30 @@ func ExtractGitInfo() (string, string, string, error) {
 
 	re := regexp.MustCompile(`(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/*(.*)\.git`)
 	matches := re.FindStringSubmatch(url)
-	if len(matches) > 5 {
-		return "", "", "", fmt.Errorf("Invalid Git URL format: %s", url)
-	}
+	// matches[0] - url itself
+	// matches[1] - protocol (ssh, http(s))
+	// matches[2] - user (in case of ssh)
+	// matches[3] - gitlab server name
+	// matches[4] - port
+	// matches[5] - project full path
+	// i.e. 'https://gitlab.organization.com/some.compex.path.to/project' will be parsed as
+	// matches[0] - https://gitlab.organization.com/some.compex.path.to/project
+	// matches[1] - http://
+	// matches[2] -
+	// matches[3] - gitlab.organization.com
+	// matches[4] -
+	// matches[5] - some.complex.path.to/project
 
-	projectPath := matches[5]
+	if matches[5] == "" {
+		return "", "", "", fmt.Errorf("Failed to retrieve project path from Git URL: %s", url)
+	}
 
 	branch, err := getCurrentBranch()
 	if err != nil {
 		return "", "", "", fmt.Errorf("Failed to get current branch: %v", err)
 	}
 
-	return url, projectPath, branch, nil
+	return url, matches[5], branch, nil
 }
 
 /* Gets the current branch */

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,17 +11,17 @@ import (
 )
 
 func main() {
-	url, namespace, projectName, branchName, err := ExtractGitInfo()
+	url, projectPath, branchName, err := ExtractGitInfo()
 	if err != nil {
 		log.Fatalf("Failed to get git namespace, project, branch, or url: %v", err)
 	}
 
 	var c Client
-	if err := c.initGitlabClient(); err != nil {
+	if err = c.initGitlabClient(); err != nil {
 		log.Fatalf("Failed to initialize Gitlab client: %v", err)
 	}
 
-	if err := c.initProjectSettings(url, namespace, projectName, branchName); err != nil {
+	if err = c.initProjectSettings(url, projectPath, branchName); err != nil {
 		log.Fatalf("Failed to initialize project settings: %v", err)
 	}
 


### PR DESCRIPTION
Current implementation of getting project full path doesn't works well for urls with groups defined like this:
`https://gitlab.organization.com/some.compex.path.to/internal/project.git`
Instead of fetching `some.compex.path.to/internal/project` it builds `internal/project` path which leads to incorrect project info request and plugin fails with the following error:
`gitlab.nvim: 2023/11/17 11:51:47 Failed to initialize project settings: Error getting project at https://git.organization.com/some.complex.path.to/internal/project.git%!(EXTRA *gitlab.ErrorResponse=GET https://git.organization.com//api/v4/projects/internal/project: 404 {message: 404 Project Not Found})`

As part of this PR regex was changed to `(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/*(.*)`

You can play with regex here: https://regex101.com/r/knjb7j/1

The following test cases have been executed
#### `GITLAB_TOKEN` env is defined, `GITLAB_URL` env is NOT defined, `.gitlab.nvim` file is NOT defined, 
1. set env variable `GITLAB_TOKEN` with token for gitlab.com
2. clone `gitlab.com` private or public project locally and switch to the branch with existing open MR
3. open nvim
4. run `require("gitlab").review()`
-----PASSED-----

#### `GITLAB_TOKEN` and `GITLAB_URL` envs are defined, `.gitlab.nvim` is NOT defined
1. define **self-hosted** instance of gitlab in env variables `GITLAB_TOKEN` and `GITLAB_URL="https://gitlab.organization.com/"`
2. clone private project from self-hosted `GITLAB_URL` locally and switch to the branch with existing open MR
3. open nvim
4. run `require("gitlab").review()`
-----PASSED-----

#### `GITLAB_TOKEN` and `GITLAB_URL` envs are defined, `.gitlab.nvim` is defined
1. define **self-hosted** instance of gitlab in env variables `GITLAB_TOKEN` and `GITLAB_URL="https://gitlab.organization.com/"`
3. clone private project from GITLAB_URL locally and switch to the branch with existing open MR
4. create `.gitlab.nvim` with `auth_token` and `gitlab_url` for gitlab.com
5. open nvim
6. run `require("gitlab").review()`
-----PASSED-----

#### `GITLAB_TOKEN` and `GITLAB_URL` envs are NOT defined, `.gitlab.nvim` is defined
1. clone private project from GITLAB_URL locally and switch to the branch with existing open MR
2. create `.gitlab.nvim` with `auth_token` and `gitlab_url` for gitlab.com
3. open nvim
4. run `require("gitlab").review()`
-----PASSED-----

-----------------------------------------------------
Tested on projects with the following URL structure:
1. Gitlab.com user project `https://gitlab.com/user/project`
2. Self-hosted gitlab project with groups defined `https://gitlab.organization.com/some.compex.path.to/internal/project.git`
3. Self-hosted user project `https://gitlab.organization.com/user/project`

Related issue is #77 