### PR TITLE
Feat: Add reviewers to summary metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ require("gitlab").setup({
     exit = "<Esc>",
     perform_action = "<leader>s", -- Once in normal mode, does action (like saving comment or editing description, etc)
     perform_linewise_action = "<leader>l", -- Once in normal mode, does the linewise action (see logs for this job, etc)
-},
+  },
   discussion_tree = { -- The discussion tree that holds all comments
     blacklist = {}, -- List of usernames to remove from tree (bots, CI, etc)
     jump_to_file = "o", -- Jump to comment location in file

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ require("gitlab").setup({
       "draft",
       "conflicts",
       "assignees",
+      "reviewers",
       "branch",
       "pipeline",
     },

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -126,6 +126,7 @@ M.build_info_lines = function()
     draft = { title = "Draft", content = (info.draft and "Yes" or "No") },
     conflicts = { title = "Merge Conflicts", content = (info.has_conflicts and "Yes" or "No") },
     assignees = { title = "Assignees", content = u.make_readable_list(info.assignees, "name") },
+    reviewers = { title = "Reviewers", content = u.make_readable_list(info.reviewers, "name") },
     branch = { title = "Branch", content = info.source_branch },
     pipeline = {
       title = "Pipeline Status:",

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -45,6 +45,7 @@ M.settings = {
       "draft",
       "conflicts",
       "assignees",
+      "reviewers",
       "branch",
       "pipeline",
     },


### PR DESCRIPTION
This commit makes it possible to show reviewers in the metadata panel of the Summary. It does not change the default configuration, though.