### PR TITLE
Bugfix: Fixes Shutdown Error Handling

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,8 +33,12 @@ func startServer(client *Client, projectInfo *ProjectInfo) {
 	go func() {
 		err := server.Serve(l)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error starting server: %s\n", err)
-			os.Exit(1)
+			if errors.Is(err, http.ErrServerClosed) {
+				os.Exit(0)
+			} else {
+				fmt.Fprintf(os.Stderr, "Server did not respond: %s\n", err)
+				os.Exit(1)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Fixes an issue with the "shutdown" command. We need to check that the error returned is a non-shutdown error.