### PR TITLE
Fix: Set correct zindex for Help pupup and don't add help kyemap for …

### DIFF
--- a/lua/gitlab/actions/help.lua
+++ b/lua/gitlab/actions/help.lua
@@ -16,10 +16,10 @@ M.open = function()
   end
   local longest_line = u.get_longest_string(help_content_lines)
   local help_popup =
-    Popup(u.create_popup_state("Help", state.settings.popup.help, longest_line + 3, #help_content_lines + 3))
+    Popup(u.creape_popup_state("Help", state.settings.popup.help, longest_line + 3, #help_content_lines + 3, 60))
   help_popup:mount()
 
-  state.set_popup_keymaps(help_popup, nil, nil)
+  state.set_popup_keymaps(help_popup, "Help", nil)
   local currentBuffer = vim.api.nvim_get_current_buf()
   vim.api.nvim_buf_set_lines(currentBuffer, 0, #help_content_lines, false, help_content_lines)
 end

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -242,10 +242,12 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
     exit(popup, opts.cb)
   end, { buffer = popup.bufnr, desc = "Exit popup" })
 
-  vim.keymap.set("n", M.settings.help, function()
-    local help = require("gitlab.actions.help")
-    help.open()
-  end, { buffer = popup.bufnr, desc = "Open help" })
+  if action ~= "Help" then -- Don't show help on the help popup
+    vim.keymap.set("n", M.settings.help, function()
+      local help = require("gitlab.actions.help")
+      help.open()
+    end, { buffer = popup.bufnr, desc = "Open help" })
+  end
   if action ~= nil then
     vim.keymap.set("n", M.settings.popup.perform_action, function()
       local text = u.get_buffer_text(popup.bufnr)

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -350,7 +350,7 @@ end
 ---@param width number? Override default width
 ---@param height number? Override default height
 ---@return table
-M.create_popup_state = function(title, settings, width, height)
+M.create_popup_state = function(title, settings, width, height, zindex)
   local default_settings = require("gitlab.state").settings.popup
   local user_settings = settings or {}
   local view_opts = {
@@ -360,6 +360,7 @@ M.create_popup_state = function(title, settings, width, height)
     relative = "editor",
     enter = true,
     focusable = true,
+    zindex = zindex or 50,
     border = {
       style = user_settings.border or default_settings.border,
       text = {


### PR DESCRIPTION
The PR title pretty much says it all (at least it did before it was truncated :)). Without setting a higher zindex on the Help popup it is not rendered correctly on top of other popups, such as Comments.

Also, it seems unnecessary to create the Help keymap in the Help popup itself as this can create multiple small popups on top of each other, that are difficult to get rid of.

I'd also suggest to change the default keybinding for Help to "g?", as it seems useful to me to keep the possibility for backward search in the Discussion tree and in other popups. Since this can be configured in user settings, this is no bid deal.