### PR TITLE
Bugfix: Pipeline Job Names w/ Whitespace

### DIFF
--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -74,13 +74,14 @@ M.open = function()
 
     for _, pipeline_job in ipairs(pipeline_jobs) do
       local offset = row_offset(pipeline_job.name)
-      local row = pipeline_job.name
-        .. offset
-        .. (state.settings.pipeline[pipeline_job.status] or "*")
-        .. " "
-        .. "("
-        .. (pipeline_job.status or "")
-        .. ")"
+      local row = string.format(
+        "%s%s %s (%s)",
+        pipeline_job.name,
+        offset,
+        state.settings.pipeline[pipeline_job.status] or "*",
+        pipeline_job.status or ""
+      )
+
       table.insert(lines, row)
     end
 
@@ -157,17 +158,14 @@ M.see_logs = function()
     end
 
     M.pipeline_popup:unmount()
-    vim.cmd.enew()
 
+    vim.cmd.tabnew()
     bufnr = vim.api.nvim_get_current_buf()
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
     -- TODO: Fix for Windows
     local job_file_path = string.format("/tmp/gitlab.nvim.job-%d", j.id)
     vim.cmd("w! " .. job_file_path)
-    vim.cmd.bd()
-
-    vim.cmd.enew()
     vim.cmd("term cat " .. job_file_path)
   end)
 end

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -43,7 +43,7 @@ M.open = function()
     local height = 6 + #pipeline_jobs + 3
 
     local pipeline_popup =
-        Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height))
+      Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height))
     M.pipeline_popup = pipeline_popup
     pipeline_popup:mount()
 
@@ -62,7 +62,9 @@ M.open = function()
     table.insert(lines, "")
     table.insert(lines, "Jobs:")
 
-    local longest_title = u.get_longest_string(u.map(pipeline_jobs, function(v) return v.name end))
+    local longest_title = u.get_longest_string(u.map(pipeline_jobs, function(v)
+      return v.name
+    end))
 
     local function row_offset(name)
       local offset = longest_title - string.len(name)
@@ -72,14 +74,13 @@ M.open = function()
 
     for _, pipeline_job in ipairs(pipeline_jobs) do
       local offset = row_offset(pipeline_job.name)
-      local row =
-          pipeline_job.name ..
-          offset ..
-          (state.settings.pipeline[pipeline_job.status] or "*") ..
-          " " ..
-          "(" ..
-          (pipeline_job.status or "")
-          .. ")"
+      local row = pipeline_job.name
+        .. offset
+        .. (state.settings.pipeline[pipeline_job.status] or "*")
+        .. " "
+        .. "("
+        .. (pipeline_job.status or "")
+        .. ")"
       table.insert(lines, row)
     end
 

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -163,10 +163,13 @@ M.see_logs = function()
     bufnr = vim.api.nvim_get_current_buf()
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
-    -- TODO: Fix for Windows
-    local job_file_path = string.format("/tmp/gitlab.nvim.job-%d", j.id)
+    local temp_file = os.tmpname()
+    local job_file_path = string.format(temp_file, j.id)
+
     vim.cmd("w! " .. job_file_path)
     vim.cmd("term cat " .. job_file_path)
+
+    vim.api.nvim_buf_set_name(0, job_name)
   end)
 end
 

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -177,7 +177,7 @@ M.format_to_local = function(date_string, offset)
     -- 2021-01-01T00:00:00.000-05:00
     local tzOffsetSign, tzOffsetHour, tzOffsetMin
     year, month, day, hour, min, sec, _, tzOffsetSign, tzOffsetHour, tzOffsetMin =
-      date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
+        date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
     tzOffset = tzOffsetSign .. tzOffsetHour .. tzOffsetMin
   end
 
@@ -224,6 +224,14 @@ M.get_longest_string = function(list)
     end
   end
   return longest
+end
+
+M.map = function(tbl, f)
+  local t = {}
+  for k, v in pairs(tbl) do
+    t[k] = f(v)
+  end
+  return t
 end
 
 M.notify = function(msg, lvl)

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -177,7 +177,7 @@ M.format_to_local = function(date_string, offset)
     -- 2021-01-01T00:00:00.000-05:00
     local tzOffsetSign, tzOffsetHour, tzOffsetMin
     year, month, day, hour, min, sec, _, tzOffsetSign, tzOffsetHour, tzOffsetMin =
-        date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
+      date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
     tzOffset = tzOffsetSign .. tzOffsetHour .. tzOffsetMin
   end
 


### PR DESCRIPTION
Fixes pipeline output.

We had a naive solution that assumed names would not have whitespace characters, this fixes printing to pipeline buffer + getting local logs w/ whitespace