### PR TITLE
Feat: Skip Tags + Releases

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -40,3 +40,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.tag.outputs.tag }}
           body: ${{ github.event.head_commit.message }}
+          skipIfReleaseExists: true # Do not release if NONE tag is used above


### PR DESCRIPTION
This will let us skip releases with the NONE keyword (no tags, no release) for small things like README tweaks or pipeline changes.

NONE