### PR TITLE
Feat: Adds Ability to Merge MR

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ require("gitlab").setup({
     success = "✓",
     failed = "",
   },
+  merge = {
+    squash = false,
+    delete_branch = false,
+  },
   colors = {
     discussion_tree = {
       username = "Keyword",
@@ -391,6 +395,7 @@ vim.keymap.set("n", "glra", gitlab.add_reviewer)
 vim.keymap.set("n", "glrd", gitlab.delete_reviewer)
 vim.keymap.set("n", "glp", gitlab.pipeline)
 vim.keymap.set("n", "glo", gitlab.open_in_browser)
+vim.keymap.set("n", "glM", gitlab.merge)
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ require("gitlab").setup({
     note = nil,
     pipeline = nil,
     reply = nil,
+    squash_message = nil,
   },
   discussion_tree = { -- The discussion tree that holds all comments
     auto_open = true, -- Automatically open when the reviewer is opened

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ require("gitlab").merge({ squash = false, delete_branch = false })
 
 You can configure default behaviors via the setup function, values passed into this function will override the defaults.
 
+If you enable `squash` you will be prompted for a squash message. To use the default message, leave the popup empty. Use the `settings.popup.perform_action` to merge the MR with your message.
+
 ### Discussions and Notes
 
 Gitlab groups threads of comments together into "discussions."

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://github.com/harrisoncramer/gitlab.nvim/assets/32515581/dc5c07de-4ae6-4335
 - [Usage](#usage)
   - [The summary command](#summary)
   - [Reviewing Diffs](#reviewing-diffs)
+  - [Merging](#merging-an-mr)
   - [Discussions and Notes](#discussions-and-notes)
   - [Discussion signs and diagnostics](#discussion-signs-and-diagnostics)
   - [Uploading Files](#uploading-files)
@@ -261,6 +262,16 @@ require("gitlab").create_comment_suggestion()
 ```
 
 For suggesting changes you can use `create_comment_suggestion` in visual mode which works similar to `create_multiline_comment` but prefills the comment window with Gitlab's [suggest changes](https://docs.gitlab.com/ee/user/project/merge_requests/reviews/suggestions.html) code block with prefilled code from the visual selection.
+
+### Merging an MR
+
+The `merge` action will merge an MR. The MR must be in a "mergeable" state for this command to work.
+
+```lua
+require("gitlab").merge({ squash = false, delete_branch = false })
+```
+
+You can configure default behaviors via the setup function, values passed into this function will override the defaults.
 
 ### Discussions and Notes
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ For suggesting changes you can use `create_comment_suggestion` in visual mode wh
 The `merge` action will merge an MR. The MR must be in a "mergeable" state for this command to work.
 
 ```lua
+require("gitlab").merge()
 require("gitlab").merge({ squash = false, delete_branch = false })
 ```
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ require("gitlab").setup({
     success = "✓",
     failed = "",
   },
-  merge = {
+  merge = { -- The default behaviors when merging an MR, see "Merging an MR"
     squash = false,
     delete_branch = false,
   },

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -9,9 +9,8 @@ import (
 )
 
 type AcceptMergeRequestRequest struct {
-	Squash             bool   `json:"squash"`
-	MergeMessage       string `json:"merge_message"`
-	RemoveSourceBranch bool   `json:"remove_source_branch"`
+	Squash             bool `json:"squash"`
+	RemoveSourceBranch bool `json:"remove_source_branch"`
 }
 
 /* acceptAndMergeHandler merges a given merge request into the target branch */
@@ -39,7 +38,6 @@ func (a *api) acceptAndMergeHandler(w http.ResponseWriter, r *http.Request) {
 	opts := gitlab.AcceptMergeRequestOptions{
 		Squash:                   &acceptAndMergeRequest.Squash,
 		ShouldRemoveSourceBranch: &acceptAndMergeRequest.RemoveSourceBranch,
-		MergeCommitMessage:       &acceptAndMergeRequest.MergeMessage,
 	}
 
 	_, res, err := a.client.AcceptMergeRequest(a.projectInfo.ProjectId, a.projectInfo.MergeId, &opts)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -9,8 +9,9 @@ import (
 )
 
 type AcceptMergeRequestRequest struct {
-	Squash       bool `json:"squash"`
-	DeleteBranch bool `json:"delete_branch"`
+	Squash        bool   `json:"squash"`
+	SquashMessage string `json:"squash_message"`
+	DeleteBranch  bool   `json:"delete_branch"`
 }
 
 /* acceptAndMergeHandler merges a given merge request into the target branch */
@@ -38,6 +39,10 @@ func (a *api) acceptAndMergeHandler(w http.ResponseWriter, r *http.Request) {
 	opts := gitlab.AcceptMergeRequestOptions{
 		Squash:                   &acceptAndMergeRequest.Squash,
 		ShouldRemoveSourceBranch: &acceptAndMergeRequest.DeleteBranch,
+	}
+
+	if acceptAndMergeRequest.SquashMessage != "" {
+		opts.SquashCommitMessage = &acceptAndMergeRequest.SquashMessage
 	}
 
 	_, res, err := a.client.AcceptMergeRequest(a.projectInfo.ProjectId, a.projectInfo.MergeId, &opts)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -9,8 +9,8 @@ import (
 )
 
 type AcceptMergeRequestRequest struct {
-	Squash             bool `json:"squash"`
-	RemoveSourceBranch bool `json:"remove_source_branch"`
+	Squash       bool `json:"squash"`
+	DeleteBranch bool `json:"delete_branch"`
 }
 
 /* acceptAndMergeHandler merges a given merge request into the target branch */
@@ -37,7 +37,7 @@ func (a *api) acceptAndMergeHandler(w http.ResponseWriter, r *http.Request) {
 
 	opts := gitlab.AcceptMergeRequestOptions{
 		Squash:                   &acceptAndMergeRequest.Squash,
-		ShouldRemoveSourceBranch: &acceptAndMergeRequest.RemoveSourceBranch,
+		ShouldRemoveSourceBranch: &acceptAndMergeRequest.DeleteBranch,
 	}
 
 	_, res, err := a.client.AcceptMergeRequest(a.projectInfo.ProjectId, a.projectInfo.MergeId, &opts)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+type AcceptMergeRequestRequest struct {
+	Squash             bool   `json:"squash"`
+	MergeMessage       string `json:"merge_message"`
+	RemoveSourceBranch bool   `json:"remove_source_branch"`
+}
+
+/* mergeHandler merges a given merge request into the target branch */
+func (a *api) mergeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Methods", http.MethodGet)
+	if r.Method != "POST" {
+		handleError(w, InvalidRequestError{}, "Expected GET", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		handleError(w, err, "Could not read request body", http.StatusBadRequest)
+		return
+	}
+
+	var acceptMergeRequest AcceptMergeRequestRequest
+	err = json.Unmarshal(body, &acceptMergeRequest)
+	if err != nil {
+		handleError(w, err, "Could not unmarshal request body", http.StatusBadRequest)
+		return
+	}
+
+	opts := gitlab.AcceptMergeRequestOptions{
+		Squash:                   &acceptMergeRequest.Squash,
+		ShouldRemoveSourceBranch: &acceptMergeRequest.RemoveSourceBranch,
+		MergeCommitMessage:       &acceptMergeRequest.MergeMessage,
+	}
+
+	a.client.AcceptMergeRequest(a.projectInfo.ProjectId, a.projectInfo.MergeId, &opts)
+
+}

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+func acceptAndMergeFn(pid interface{}, mergeRequest int, opt *gitlab.AcceptMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	return &gitlab.MergeRequest{}, makeResponse(http.StatusOK), nil
+}
+
+func acceptAndMergeFnErr(pid interface{}, mergeRequest int, opt *gitlab.AcceptMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	return nil, nil, errors.New("Some error from Gitlab")
+}
+
+func acceptAndMergeNon200(pid interface{}, mergeRequest int, opt *gitlab.AcceptMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	return nil, makeResponse(http.StatusSeeOther), nil
+}
+
+func TestAcceptAndMergeHandler(t *testing.T) {
+	t.Run("Accepts and merges a merge request", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/merge", AcceptMergeRequestRequest{})
+		server, _ := createRouterAndApi(fakeClient{acceptAndMergeFn: acceptAndMergeFn})
+		data := serveRequest(t, server, request, SuccessResponse{})
+		assert(t, data.Message, "MR merged successfully")
+		assert(t, data.Status, http.StatusOK)
+	})
+
+	t.Run("Disallows non-POST methods", func(t *testing.T) {
+		request := makeRequest(t, http.MethodGet, "/merge", AcceptMergeRequestRequest{})
+		server, _ := createRouterAndApi(fakeClient{acceptAndMergeFn: acceptAndMergeFn})
+		data := serveRequest(t, server, request, ErrorResponse{})
+		checkBadMethod(t, *data, http.MethodPost)
+	})
+
+	t.Run("Handles errors from Gitlab client", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/merge", AcceptMergeRequestRequest{})
+		server, _ := createRouterAndApi(fakeClient{acceptAndMergeFn: acceptAndMergeFnErr})
+		data := serveRequest(t, server, request, ErrorResponse{})
+		checkErrorFromGitlab(t, *data, "Could not merge MR")
+	})
+
+	t.Run("Handles non-200s from Gitlab client", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/merge", AcceptMergeRequestRequest{})
+		server, _ := createRouterAndApi(fakeClient{acceptAndMergeFn: acceptAndMergeNon200})
+		data := serveRequest(t, server, request, ErrorResponse{})
+		checkNon200(t, *data, "Could not merge MR", "/merge")
+	})
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -105,7 +105,7 @@ func createRouterAndApi(client ClientInterface, optFuncs ...optFunc) (*http.Serv
 	m.HandleFunc("/shutdown", a.shutdownHandler)
 	m.HandleFunc("/approve", a.approveHandler)
 	m.HandleFunc("/comment", a.commentHandler)
-	m.HandleFunc("/merge", a.mergeHandler)
+	m.HandleFunc("/merge", a.acceptAndMergeHandler)
 	m.HandleFunc("/discussions/list", a.listDiscussionsHandler)
 	m.HandleFunc("/discussions/resolve", a.discussionsResolveHandler)
 	m.HandleFunc("/info", a.infoHandler)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -105,6 +105,7 @@ func createRouterAndApi(client ClientInterface, optFuncs ...optFunc) (*http.Serv
 	m.HandleFunc("/shutdown", a.shutdownHandler)
 	m.HandleFunc("/approve", a.approveHandler)
 	m.HandleFunc("/comment", a.commentHandler)
+	m.HandleFunc("/merge", a.mergeHandler)
 	m.HandleFunc("/discussions/list", a.listDiscussionsHandler)
 	m.HandleFunc("/discussions/resolve", a.discussionsResolveHandler)
 	m.HandleFunc("/info", a.infoHandler)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -20,6 +20,7 @@ The FakeHandlerClient is used to create a fake gitlab client for testing our han
 type fakeClient struct {
 	getMergeRequestFn                func(pid interface{}, mergeRequest int, opt *gitlab.GetMergeRequestsOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error)
 	updateMergeRequestFn             func(pid interface{}, mergeRequest int, opt *gitlab.UpdateMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error)
+	acceptAndMergeFn                 func(pid interface{}, mergeRequest int, opt *gitlab.AcceptMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error)
 	unapprorveMergeRequestFn         func(pid interface{}, mr int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 	uploadFile                       func(pid interface{}, content io.Reader, filename string, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectFile, *gitlab.Response, error)
 	getMergeRequestDiffVersions      func(pid interface{}, mergeRequest int, opt *gitlab.GetMergeRequestDiffVersionsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequestDiffVersion, *gitlab.Response, error)
@@ -44,6 +45,10 @@ type Author struct {
 	State     string `json:"state"`
 	AvatarURL string `json:"avatar_url"`
 	WebURL    string `json:"web_url"`
+}
+
+func (f fakeClient) AcceptMergeRequest(pid interface{}, mergeRequest int, opt *gitlab.AcceptMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	return f.acceptAndMergeFn(pid, mergeRequest, opt, options...)
 }
 
 func (f fakeClient) GetMergeRequest(pid interface{}, mergeRequest int, opt *gitlab.GetMergeRequestsOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error) {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -36,6 +36,7 @@ func (e InvalidRequestError) Error() string {
 /* The ClientInterface interface implements all the methods that our handlers need */
 type ClientInterface interface {
 	GetMergeRequest(pid interface{}, mr int, opt *gitlab.GetMergeRequestsOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error)
+	AcceptMergeRequest(pid interface{}, mergeRequest int, opt *gitlab.AcceptMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error)
 	UpdateMergeRequest(pid interface{}, mr int, opt *gitlab.UpdateMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error)
 	UploadFile(pid interface{}, content io.Reader, filename string, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectFile, *gitlab.Response, error)
 	GetMergeRequestDiffVersions(pid interface{}, mr int, opt *gitlab.GetMergeRequestDiffVersionsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequestDiffVersion, *gitlab.Response, error)

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -5,16 +5,26 @@ local reviewer = require("gitlab.reviewer")
 
 local M = {}
 
-M.merge = function()
+---@class MergeOpts
+---@field delete_branch boolean?
+---@field squash boolean?
+
+---@param opts MergeOpts
+M.merge = function(opts)
   local merge_body = { squash = state.settings.merge.squash, delete_branch = state.settings.merge.delete_branch }
+  if opts then
+    merge_body.squash = opts.squash ~= nil and opts.squash
+    merge_body.delete_branch = opts.delete_branch ~= nil and opts.delete_branch
+  end
+
   if state.INFO.detailed_merge_status ~= "mergeable" then
     u.notify(string.format("MR not mergeable, currently '%s'", state.INFO.detailed_merge_status), vim.log.levels.ERROR)
     return
   end
 
   job.run_job("/merge", "POST", merge_body, function(data)
-    u.notify(data.message, vim.log.levels.INFO)
     reviewer.close()
+    u.notify(data.message, vim.log.levels.INFO)
   end)
 end
 

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -1,0 +1,19 @@
+local u = require("gitlab.utils")
+local state = require("gitlab.state")
+local job = require("gitlab.job")
+
+local M = {}
+
+M.merge = function()
+  local merge_body = { squash = state.settings.merge.squash, delete_branch = state.settings.merge.delete_branch }
+  if state.INFO.detailed_merge_status ~= "mergeable" then
+    u.notify(
+      string.format("MR not mergeable, currently '%s'", state.INFO.detailed_merge_status),
+      vim.log.levels.ERROR)
+    return
+  end
+
+  job.run_job("/merge", "POST", merge_body)
+end
+
+return M

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -28,7 +28,6 @@ M.merge = function(opts)
     return
   end
 
-
   if not merge_body.squash then
     local squash_message_popup = create_squash_message_popup()
     squash_message_popup:mount()
@@ -36,8 +35,13 @@ M.merge = function(opts)
       M.confirm_merge(merge_body, text)
     end)
     vim.schedule(function()
-      vim.api.nvim_buf_set_lines(squash_message_popup.bufnr, 0, -1, false,
-        { "# Add your squash commit message. Comment lines will be ignored." })
+      vim.api.nvim_buf_set_lines(
+        squash_message_popup.bufnr,
+        0,
+        -1,
+        false,
+        { "# Add your squash commit message. Comment lines will be ignored." }
+      )
     end)
   else
     M.confirm_merge(merge_body)

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -28,20 +28,11 @@ M.merge = function(opts)
     return
   end
 
-  if not merge_body.squash then
+  if merge_body.squash then
     local squash_message_popup = create_squash_message_popup()
     squash_message_popup:mount()
     state.set_popup_keymaps(squash_message_popup, function(text)
       M.confirm_merge(merge_body, text)
-    end)
-    vim.schedule(function()
-      vim.api.nvim_buf_set_lines(
-        squash_message_popup.bufnr,
-        0,
-        -1,
-        false,
-        { "# Add your squash commit message. Comment lines will be ignored." }
-      )
     end)
   else
     M.confirm_merge(merge_body)
@@ -52,9 +43,9 @@ end
 ---@param squash_message string?
 M.confirm_merge = function(merge_body, squash_message)
   if squash_message ~= nil then
-    local msg = u.strip_comments(squash_message)
-    merge_body.squash_message = msg
+    merge_body.squash_message = squash_message
   end
+
   job.run_job("/merge", "POST", merge_body, function(data)
     reviewer.close()
     u.notify(data.message, vim.log.levels.INFO)

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -1,6 +1,7 @@
 local u = require("gitlab.utils")
 local state = require("gitlab.state")
 local job = require("gitlab.job")
+local reviewer = require("gitlab.reviewer")
 
 local M = {}
 
@@ -11,7 +12,10 @@ M.merge = function()
     return
   end
 
-  job.run_job("/merge", "POST", merge_body)
+  job.run_job("/merge", "POST", merge_body, function(data)
+    u.notify(data.message, vim.log.levels.INFO)
+    reviewer.close()
+  end)
 end
 
 return M

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -1,13 +1,19 @@
 local u = require("gitlab.utils")
+local Popup = require("nui.popup")
 local state = require("gitlab.state")
 local job = require("gitlab.job")
 local reviewer = require("gitlab.reviewer")
 
 local M = {}
 
+local function create_squash_message_popup()
+  return Popup(u.create_popup_state("Squash Commit Message", state.settings.popup.squash_message))
+end
+
 ---@class MergeOpts
 ---@field delete_branch boolean?
 ---@field squash boolean?
+---@field squash_message string?
 
 ---@param opts MergeOpts
 M.merge = function(opts)
@@ -22,6 +28,29 @@ M.merge = function(opts)
     return
   end
 
+
+  if not merge_body.squash then
+    local squash_message_popup = create_squash_message_popup()
+    squash_message_popup:mount()
+    state.set_popup_keymaps(squash_message_popup, function(text)
+      M.confirm_merge(merge_body, text)
+    end)
+    vim.schedule(function()
+      vim.api.nvim_buf_set_lines(squash_message_popup.bufnr, 0, -1, false,
+        { "# Add your squash commit message. Comment lines will be ignored." })
+    end)
+  else
+    M.confirm_merge(merge_body)
+  end
+end
+
+---@param merge_body MergeOpts
+---@param squash_message string?
+M.confirm_merge = function(merge_body, squash_message)
+  if squash_message ~= nil then
+    local msg = u.strip_comments(squash_message)
+    merge_body.squash_message = msg
+  end
   job.run_job("/merge", "POST", merge_body, function(data)
     reviewer.close()
     u.notify(data.message, vim.log.levels.INFO)

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -7,9 +7,7 @@ local M = {}
 M.merge = function()
   local merge_body = { squash = state.settings.merge.squash, delete_branch = state.settings.merge.delete_branch }
   if state.INFO.detailed_merge_status ~= "mergeable" then
-    u.notify(
-      string.format("MR not mergeable, currently '%s'", state.INFO.detailed_merge_status),
-      vim.log.levels.ERROR)
+    u.notify(string.format("MR not mergeable, currently '%s'", state.INFO.detailed_merge_status), vim.log.levels.ERROR)
     return
   end
 

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -138,7 +138,9 @@ M.build_info_lines = function()
 
   local longest_used = ""
   for _, v in ipairs(state.settings.info.fields) do
-    if v == "merge_status" then v = "detailed_merge_status" end -- merge_status was deprecated, see https://gitlab.com/gitlab-org/gitlab/-/issues/3169#note_1162532204
+    if v == "merge_status" then
+      v = "detailed_merge_status"
+    end -- merge_status was deprecated, see https://gitlab.com/gitlab-org/gitlab/-/issues/3169#note_1162532204
     local title = options[v].title
     if string.len(title) > string.len(longest_used) then
       longest_used = title
@@ -152,7 +154,9 @@ M.build_info_lines = function()
 
   local lines = {}
   for _, v in ipairs(state.settings.info.fields) do
-    if v == "merge_status" then v = "detailed_merge_status" end
+    if v == "merge_status" then
+      v = "detailed_merge_status"
+    end
     local row = options[v]
     local line = "* " .. row.title .. row_offset(row.title)
     if type(row.content) == "function" then

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -122,7 +122,7 @@ M.build_info_lines = function()
     author = { title = "Author", content = "@" .. info.author.username .. " (" .. info.author.name .. ")" },
     created_at = { title = "Created", content = u.format_to_local(info.created_at, vim.fn.strftime("%z")) },
     updated_at = { title = "Updated", content = u.format_to_local(info.updated_at, vim.fn.strftime("%z")) },
-    merge_status = { title = "Status", content = info.detailed_merge_status },
+    detailed_merge_status = { title = "Status", content = info.detailed_merge_status },
     draft = { title = "Draft", content = (info.draft and "Yes" or "No") },
     conflicts = { title = "Merge Conflicts", content = (info.has_conflicts and "Yes" or "No") },
     assignees = { title = "Assignees", content = u.make_readable_list(info.assignees, "name") },
@@ -138,6 +138,7 @@ M.build_info_lines = function()
 
   local longest_used = ""
   for _, v in ipairs(state.settings.info.fields) do
+    if v == "merge_status" then v = "detailed_merge_status" end -- merge_status was deprecated, see https://gitlab.com/gitlab-org/gitlab/-/issues/3169#note_1162532204
     local title = options[v].title
     if string.len(title) > string.len(longest_used) then
       longest_used = title
@@ -151,6 +152,7 @@ M.build_info_lines = function()
 
   local lines = {}
   for _, v in ipairs(state.settings.info.fields) do
+    if v == "merge_status" then v = "detailed_merge_status" end
     local row = options[v]
     local line = "* " .. row.title .. row_offset(row.title)
     if type(row.content) == "function" then

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -28,7 +28,7 @@ return {
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
   end,
   -- Global Actions 🌎
-  summary = async.sequence({ info }, summary.summary),
+  summary = async.sequence({ u.merge(info, { refresh = true }) }, summary.summary),
   approve = async.sequence({ info }, approvals.approve),
   revoke = async.sequence({ info }, approvals.revoke),
   add_reviewer = async.sequence({ info, project_members }, assignees_and_reviewers.add_reviewer),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -4,6 +4,7 @@ local server = require("gitlab.server")
 local state = require("gitlab.state")
 local reviewer = require("gitlab.reviewer")
 local discussions = require("gitlab.actions.discussions")
+local merge = require("gitlab.actions.merge")
 local summary = require("gitlab.actions.summary")
 local assignees_and_reviewers = require("gitlab.actions.assignees_and_reviewers")
 local comment = require("gitlab.actions.comment")
@@ -20,9 +21,9 @@ return {
     if args == nil then
       args = {}
     end
-    server.build() -- Builds the Go binary if it doesn't exist
-    state.merge_settings(args) -- Sets keymaps and other settings from setup function
-    require("gitlab.colors") -- Sets colors
+    server.build()                       -- Builds the Go binary if it doesn't exist
+    state.merge_settings(args)           -- Sets keymaps and other settings from setup function
+    require("gitlab.colors")             -- Sets colors
     reviewer.init()
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
   end,
@@ -43,6 +44,7 @@ return {
     reviewer.open()
   end),
   pipeline = async.sequence({ info }, pipeline.open),
+  merge = async.sequence({ info }, merge.merge),
   -- Discussion Tree Actions 🌴
   toggle_discussions = async.sequence({ info }, discussions.toggle),
   edit_comment = async.sequence({ info }, discussions.edit_comment),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -47,7 +47,7 @@ return {
     reviewer.close()
   end,
   pipeline = async.sequence({ info }, pipeline.open),
-  merge = async.sequence({ info }, merge.merge),
+  merge = async.sequence({ u.merge(info, { refresh = true }) }, merge.merge),
   -- Discussion Tree Actions 🌴
   toggle_discussions = async.sequence({ info }, discussions.toggle),
   edit_comment = async.sequence({ info }, discussions.edit_comment),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -21,9 +21,9 @@ return {
     if args == nil then
       args = {}
     end
-    server.build()                       -- Builds the Go binary if it doesn't exist
-    state.merge_settings(args)           -- Sets keymaps and other settings from setup function
-    require("gitlab.colors")             -- Sets colors
+    server.build() -- Builds the Go binary if it doesn't exist
+    state.merge_settings(args) -- Sets keymaps and other settings from setup function
+    require("gitlab.colors") -- Sets colors
     reviewer.init()
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
   end,

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -43,6 +43,9 @@ return {
   review = async.sequence({ u.merge(info, { refresh = true }), revisions }, function()
     reviewer.open()
   end),
+  close_review = function()
+    reviewer.close()
+  end,
   pipeline = async.sequence({ info }, pipeline.open),
   merge = async.sequence({ info }, merge.merge),
   -- Discussion Tree Actions 🌴

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -47,6 +47,12 @@ M.open = function()
   end
 end
 
+M.close = function()
+  vim.cmd("DiffviewClose")
+  local discussions = require("gitlab.actions.discussions")
+  discussions.close()
+end
+
 M.jump = function(file_name, new_line, old_line)
   if M.tabnr == nil then
     u.notify("Can't jump to Diffvew. Is it open?", vim.log.levels.ERROR)

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -22,6 +22,9 @@ M.init = function()
   M.open = reviewer.open
   -- Opens the reviewer window
 
+  M.close = reviewer.close
+  -- Closes the reviewer and cleans up
+
   M.jump = reviewer.jump
   -- Jumps to the location provided in the reviewer window
   -- Parameters:

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -29,6 +29,7 @@ M.settings = {
     note = nil,
     help = nil,
     pipeline = nil,
+    squash_message = nil,
   },
   discussion_tree = {
     auto_open = true,
@@ -52,10 +53,10 @@ M.settings = {
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0
           and string.format("Discussions (%d/%d)", t.resolved_discussions, t.resolvable_discussions)
-        or "Discussions"
+          or "Discussions"
       local notes_content = t.resolvable_notes ~= 0
           and string.format("Notes (%d/%d)", t.resolved_notes, t.resolvable_notes)
-        or "Notes"
+          or "Notes"
       if t.name == "Discussions" then
         notes_content = "%#Comment#" .. notes_content
         discussions_content = "%#Text#" .. discussions_content
@@ -113,7 +114,7 @@ M.settings = {
     -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,
     severity = vim.diagnostic.severity.INFO,
-    code = nil, -- see :h diagnostic-structure
+    code = nil,        -- see :h diagnostic-structure
     display_opts = {}, -- this is dirrectly used as opts in vim.diagnostic.set, see :h vim.diagnostic.config.
   },
   pipeline = {

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -52,10 +52,10 @@ M.settings = {
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0
           and string.format("Discussions (%d/%d)", t.resolved_discussions, t.resolvable_discussions)
-        or "Discussions"
+          or "Discussions"
       local notes_content = t.resolvable_notes ~= 0
           and string.format("Notes (%d/%d)", t.resolved_notes, t.resolvable_notes)
-        or "Notes"
+          or "Notes"
       if t.name == "Discussions" then
         notes_content = "%#Comment#" .. notes_content
         discussions_content = "%#Text#" .. discussions_content
@@ -65,6 +65,10 @@ M.settings = {
       end
       return " " .. discussions_content .. " %#Comment#| " .. notes_content
     end,
+  },
+  merge = {
+    squash = false,
+    delete_branch = false,
   },
   info = {
     enabled = true,
@@ -109,7 +113,7 @@ M.settings = {
     -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,
     severity = vim.diagnostic.severity.INFO,
-    code = nil, -- see :h diagnostic-structure
+    code = nil,        -- see :h diagnostic-structure
     display_opts = {}, -- this is dirrectly used as opts in vim.diagnostic.set, see :h vim.diagnostic.config.
   },
   pipeline = {

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -53,10 +53,10 @@ M.settings = {
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0
           and string.format("Discussions (%d/%d)", t.resolved_discussions, t.resolvable_discussions)
-          or "Discussions"
+        or "Discussions"
       local notes_content = t.resolvable_notes ~= 0
           and string.format("Notes (%d/%d)", t.resolved_notes, t.resolvable_notes)
-          or "Notes"
+        or "Notes"
       if t.name == "Discussions" then
         notes_content = "%#Comment#" .. notes_content
         discussions_content = "%#Text#" .. discussions_content
@@ -114,7 +114,7 @@ M.settings = {
     -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,
     severity = vim.diagnostic.severity.INFO,
-    code = nil,        -- see :h diagnostic-structure
+    code = nil, -- see :h diagnostic-structure
     display_opts = {}, -- this is dirrectly used as opts in vim.diagnostic.set, see :h vim.diagnostic.config.
   },
   pipeline = {

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -52,10 +52,10 @@ M.settings = {
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0
           and string.format("Discussions (%d/%d)", t.resolved_discussions, t.resolvable_discussions)
-          or "Discussions"
+        or "Discussions"
       local notes_content = t.resolvable_notes ~= 0
           and string.format("Notes (%d/%d)", t.resolved_notes, t.resolvable_notes)
-          or "Notes"
+        or "Notes"
       if t.name == "Discussions" then
         notes_content = "%#Comment#" .. notes_content
         discussions_content = "%#Text#" .. discussions_content
@@ -113,7 +113,7 @@ M.settings = {
     -- for namespace `gitlab_discussion`. See :h vim.diagnostic.config
     enabled = true,
     severity = vim.diagnostic.severity.INFO,
-    code = nil,        -- see :h diagnostic-structure
+    code = nil, -- see :h diagnostic-structure
     display_opts = {}, -- this is dirrectly used as opts in vim.diagnostic.set, see :h vim.diagnostic.config.
   },
   pipeline = {

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -177,7 +177,7 @@ M.format_to_local = function(date_string, offset)
     -- 2021-01-01T00:00:00.000-05:00
     local tzOffsetSign, tzOffsetHour, tzOffsetMin
     year, month, day, hour, min, sec, _, tzOffsetSign, tzOffsetHour, tzOffsetMin =
-        date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
+      date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
     tzOffset = tzOffsetSign .. tzOffsetHour .. tzOffsetMin
   end
 
@@ -630,7 +630,7 @@ end
 ---@param text string
 ---@return string
 M.strip_comment_lines = function(text)
-  local new_text = ''
+  local new_text = ""
   return new_text
 end
 

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -177,7 +177,7 @@ M.format_to_local = function(date_string, offset)
     -- 2021-01-01T00:00:00.000-05:00
     local tzOffsetSign, tzOffsetHour, tzOffsetMin
     year, month, day, hour, min, sec, _, tzOffsetSign, tzOffsetHour, tzOffsetMin =
-      date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
+        date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
     tzOffset = tzOffsetSign .. tzOffsetHour .. tzOffsetMin
   end
 
@@ -624,6 +624,14 @@ M.get_icon = function(filename)
   else
     return nil, nil
   end
+end
+
+---Removes lines prefixed with the '#' comment indicator in markdown
+---@param text string
+---@return string
+M.strip_comment_lines = function(text)
+  local new_text = ''
+  return new_text
 end
 
 M.basename = function(str)

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -626,14 +626,6 @@ M.get_icon = function(filename)
   end
 end
 
----Removes lines prefixed with the '#' comment indicator in markdown
----@param text string
----@return string
-M.strip_comment_lines = function(text)
-  local new_text = ""
-  return new_text
-end
-
 M.basename = function(str)
   local name = string.gsub(str, "(.*/)(.*)", "%2")
   return name


### PR DESCRIPTION
This adds the ability to merge an MR from within gitlab.nvim directly. If the reviewer is open, it'll be closed automatically. Users may configure whether they'd like to squash commits on the merge, as well as whether they'd like to delete the original source branch on a merge.

If squashing, users are prompted to provide an optional custom squash message for the squash commit.