### PR TITLE
Fix: Discussion + Note Creation Bugs

### DIFF
--- a/lua/gitlab/actions/discussions/signs.lua
+++ b/lua/gitlab/actions/discussions/signs.lua
@@ -192,7 +192,7 @@ M.parse_diagnostics_from_discussions = function(discussions)
         return {}, {}, string.format("Unsupported line range type found for discussion %s", discussion.id)
       end
     else -- Diagnostics for single line discussions.
-      if first_note.position.new_line ~= nil then
+      if first_note.position.new_line ~= nil and first_note.position.old_line == nil then
         local new_diagnostic = {
           lnum = first_note.position.new_line - 1,
         }
@@ -306,7 +306,7 @@ M.parse_signs_from_discussions = function(discussions)
       local sign = vim.tbl_deep_extend("force", {
         id = first_note.id,
       }, base_sign)
-      if first_note.position.new_line ~= nil then
+      if first_note.position.new_line ~= nil and first_note.position.old_line == nil then
         table.insert(new_signs, vim.tbl_deep_extend("force", { lnum = first_note.position.new_line }, sign))
       end
       if first_note.position.old_line ~= nil then

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -53,7 +53,9 @@ M.update_winbar = function(discussions, unlinked_discussions, base_title)
   local d = require("gitlab.actions.discussions")
   local winId = d.split.winid
   local c = content(discussions, unlinked_discussions, base_title)
-  vim.wo[winId].winbar = c
+  if vim.wo[winId] then
+    vim.wo[winId].winbar = c
+  end
 end
 
 return M

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -121,7 +121,10 @@ M.get_location = function(range)
   local type
   local is_new
 
-  if layout.a.file.bufnr == bufnr or (M.lines_are_same(view.cur_layout) and layout.b.file.bufnr == bufnr and range == nil) then
+  if
+    layout.a.file.bufnr == bufnr
+    or (M.lines_are_same(view.cur_layout) and layout.b.file.bufnr == bufnr and range == nil)
+  then
     result.file_name = layout.a.file.path
     result.old_line = current_line
     type = "old"
@@ -157,7 +160,7 @@ M.get_location = function(range)
     result.new_line = current_line_info.new_line
   end
 
-  print(current_line_info.in_hunk)
+  vim.print(current_line_info)
 
   -- If users leave single-line comments in the new buffer that should be in the old buffer, we can
   -- tell because the line will not have changed. Send the correct payload.
@@ -174,7 +177,7 @@ M.get_location = function(range)
   end
 
   -- FIXME #2: If line has new_line properties, then don't show diagnostics in old file...
-  result.range_info = { start = {},["end"] = {} }
+  result.range_info = { start = {}, ["end"] = {} }
   if current_line == range.start_line then
     result.range_info.start.old_line = current_line_info.old_line
     result.range_info.start.new_line = current_line_info.new_line
@@ -218,7 +221,6 @@ M.lines_are_same = function(layout)
   local line_b = u.get_line_content(layout.b.file.bufnr, b_cursor)
   return line_a == line_b
 end
-
 
 ---Get currently shown file
 M.get_current_file = function()

--- a/script.lua
+++ b/script.lua
@@ -1,4 +1,0 @@
-local u = require("gitlab.utils")
-
-local res = u.parse_hunk_headers("README.md", "main")
-vim.print(res)

--- a/script.lua
+++ b/script.lua
@@ -1,0 +1,4 @@
+local u = require("gitlab.utils")
+
+local res = u.parse_hunk_headers("README.md", "main")
+vim.print(res)


### PR DESCRIPTION
This MR is an attempt to address some of the bugs/issues with discussion creation and note creation.

This is related to #128 which is occurring due to the Gitlab API's _extremely particular_ API surrounding line codes. This certainly doesn't fix all the issues but it solves a few different ones.

First, when you left a multiline ranged comment we were grabbing the CURRENT line rather than the top of your visual selection and using that as the start line, which caused issues. 

Another bug was related to leaving a comment on an unchanged line in the _new_ pane. This is solved now -- we look at the current line, and also at the linked line in the other reviewer pane. If the two are identical, then you are actually leaving a comment on an old diff, so we adjust the payload correctly.