### PR TITLE
fix: Adds missing pipeline service

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -86,6 +86,7 @@ func initGitlabClient() (error, *Client) {
 		ProjectsService:              client.Projects,
 		ProjectMembersService:        client.ProjectMembers,
 		JobsService:                  client.Jobs,
+		PipelinesService:             client.Pipelines,
 	}
 }
 


### PR DESCRIPTION
This missing service was causing errors (nil pointer exceptions) when attempting to retrigger a pipeline. This MR adds it back to the plugin.