### PR TITLE
Allow use of --imply_local when calling DiffviewOpen, allowing LSP use and linting in MR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ require("gitlab").setup({
   config_path = nil, -- Custom path for `.gitlab.nvim` file, please read the "Connecting to Gitlab" section
   debug = { go_request = false, go_response = false }, -- Which values to log
   attachment_dir = nil, -- The local directory for files (see the "summary" section)
+  reviewer_settings = {
+    diffview = {
+      imply_local = false, -- If true, will attempt to use --imply_local option when calling |:DiffviewOpen|
+    },
+  },
   help = "?", -- Opens a help popup for local keymaps when a relevant view is focused (popup, discussion panel, etc)
   popup = { -- The popup for comment creation, editing, and replying
     exit = "<Esc>",

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -136,6 +136,11 @@ you call this function with no values the defaults will be used:
       config_path = nil, -- Custom path for `.gitlab.nvim` file, please read the "Connecting to Gitlab" section
       debug = { go_request = false, go_response = false }, -- Which values to log
       attachment_dir = nil, -- The local directory for files (see the "summary" section)
+      reviewer_settings = {
+	diffview = {
+	  imply_local = false, -- If true, will attempt to use --imply_local option when calling |:DiffviewOpen|
+	},
+      },
       help = "?", -- Opens a help popup for local keymaps when a relevant view is focused (popup, discussion panel, etc)
       popup = { -- The popup for comment creation, editing, and replying
         exit = "<Esc>",

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -9,10 +9,10 @@ local M = {
   tabnr = nil,
 }
 
-local are_git_managed_files_modified = function()
-  -- check if there are any uncommitted changes to tracked files
+local all_git_manged_files_unmodified = function()
+  -- check local managed files are unmodified, matching the state in the MR
   -- TODO: ensure correct CWD?
-  return vim.fn.trim(vim.fn.system({ "git", "status", "--short", "--untracked-files=no" })) ~= ""
+  return vim.fn.trim(vim.fn.system({ "git", "status", "--short", "--untracked-files=no" })) == ""
 end
 
 M.open = function()
@@ -30,13 +30,13 @@ M.open = function()
   local diffview_open_command = "DiffviewOpen"
 
   if state.settings.reviewer_settings.diffview.imply_local then
-    if are_git_managed_files_modified() then
+    if all_git_manged_files_unmodified() then
+      diffview_open_command = diffview_open_command .. " --imply-local"
+    else
       u.notify(
         "There are uncommited changes in the working tree, cannot use 'imply_local' setting for gitlab reviews. Stash or commit all changes to use.",
         vim.log.levels.WARN
       )
-    else
-      diffview_open_command = diffview_open_command .. " --imply-local"
     end
   end
 

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -12,8 +12,7 @@ local M = {
 local are_git_managed_files_modified = function()
   -- check if there are any uncommitted changes to tracked files
   -- TODO: ensure correct CWD?
-  local status_result = vim.system({ "git", "status", "--short", "--untracked-files=no" }, { text = true }):wait()
-  return vim.fn.trim(status_result.stdout) ~= ""
+  return vim.fn.trim(vim.fn.system({ "git", "status", "--short", "--untracked-files=no" })) ~= ""
 end
 
 M.open = function()

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -13,6 +13,11 @@ M.settings = {
   log_path = (vim.fn.stdpath("cache") .. "/gitlab.nvim.log"),
   config_path = nil,
   reviewer = "diffview",
+  reviewer_settings = {
+    diffview = {
+      imply_local = false,
+    },
+  },
   attachment_dir = "",
   help = "?",
   popup = {


### PR DESCRIPTION
After this MR, gitlab.nvim will attempt to use --imply-local parameter when opening diffview reviewer, based on a new configuration setting for gitlab.nvim, which is introduced as an "opt-in" option. Previous behavior is unchanged unless gitlab.nvim is configured by user to use the new feature.

The benefit of --imply-local is that diffview will treat the current HEAD that is being reviewed as a local file, allowing full use of diagnostics in the buffer, including LSP and linters.

In case the local working tree has changes compared to the state that is being reviewed, gitlab.nvim will not use the --imply-local parameter towards diffview, because that would could potentially show local file changes which are not part of the merge request under review. In this case a warning will be dispatched, and the usual reviewer is opened, as it is without the gitlab.nvim option active.

Potential issues:
1. Stability of diffivew API and the "--imply-local" option.
2. Reliance on "cwd == git root" when checking for local changes to files.
3. It appears currently currently diffview does not set the buffer to "readonly" when --imply-local is used. This may be something to ask for a fix in their code. I find it odd that "reviewing and implying local" does not "write_protect" the window.

Created after discussion in https://github.com/harrisoncramer/gitlab.nvim/issues/156.

Relevant option in Diffview doc [here](https://github.com/sindrets/diffview.nvim/blob/main/doc/diffview.txt#L148).