### PR TITLE
Fix: De-Register Tabpage on Correct Close Event

### DIFF
--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -105,6 +105,9 @@ M.toggle = function(callback)
       return
     end
 
+    local current_window = vim.api.nvim_get_current_win() -- Save user's current window in case they switched while content was loading
+    vim.api.nvim_set_current_win(M.split.winid)
+
     M.rebuild_discussion_tree()
     M.rebuild_unlinked_discussion_tree()
     M.add_empty_titles({
@@ -118,6 +121,8 @@ M.toggle = function(callback)
 
     M.switch_can_edit_bufs(false)
     winbar.update_winbar(M.discussions, M.unlinked_discussions, default_discussions and "Discussions" or "Notes")
+
+    vim.api.nvim_set_current_win(current_window)
     if type(callback) == "function" then
       callback()
     end

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -50,17 +50,15 @@ M.open = function()
     u.notify("This merge request has conflicts!", vim.log.levels.WARN)
   end
 
-  local group = vim.api.nvim_create_augroup("gitlab.diffview.autocommand.close", {})
-  vim.api.nvim_create_autocmd("User", {
-    pattern = { "DiffviewViewClosed" },
-    group = group,
-    callback = function()
-      --Check if our diffview tab was closed
-      if vim.api.nvim_tabpage_is_valid(M.tabnr) then
-        M.tabnr = nil
-      end
-    end,
-  })
+  -- Register Diffview hook for close event to set tab page # to nil
+  local on_diffview_closed = function(view)
+    if view.tabpage == M.tabnr then
+      M.tabnr = nil
+    end
+  end
+  require("diffview.config").user_emitter:on("view_closed", function(_, ...)
+    on_diffview_closed(...)
+  end)
 
   if state.settings.discussion_tree.auto_open then
     local discussions = require("gitlab.actions.discussions")


### PR DESCRIPTION
This MR attaches to Diffview's hooks API to get the actual tabpage of a closed Diffview, so that we only register the `gitlab.nvim` reviewer as being closed when the tab numbers line up. Previously we were closing it whenever this event fired which didn't work because someone could have both Diffview and Gitlab open at the same time.