### PR TITLE
Fix: Keep empty lines in discussion tree

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -1,4 +1,4 @@
-*gitlab.nvim.txt* Create, review, and manage Gitlab reources without leaving Neovim
+*gitlab.nvim.txt* Create, review, and manage Gitlab resources without leaving Neovim
 
 ==============================================================================
 Table of Contents                              *gitlab.nvim.table-of-contents*
@@ -320,7 +320,7 @@ To prevent losing your carefully crafted note/comment/suggestion you can set
 which the contents of the popup window will be saved just before the action is
 performed. A practical setting is `settings.popup.backup_register = "+"` which
 saves to the system clipboard (see |quoteplus|). This lets you easily apply
-the action on Gitlab in a browser, if it keeps failing in `gitlab.nvim`. 
+the action on Gitlab in a browser, if it keeps failing in `gitlab.nvim`.
 
 If you experience such problems, please first read the
 |gitlab.nvim.troubleshooting| section. If it does not help, see if there are
@@ -514,7 +514,7 @@ reviewer when checking out a new branch:
 >lua
     local gitlab = require("gitlab")
     vim.keymap.set("n", "glB", function ()
-        require("gitlab.server").restart(function () 
+        require("gitlab.server").restart(function ()
             vim.cmd.tabclose()
             gitlab.review() -- Reopen the reviewer after the server restarts
         end)
@@ -630,7 +630,7 @@ reviewer pane (see the gitlab.nvim.review command), otherwise it will error.
 >lua
   require("gitlab").comment()
 
-Afer the comment is typed, submit it to Gitlab via the |settings.popup.perform_action|
+After the comment is typed, submit it to Gitlab via the |settings.popup.perform_action|
 keybinding, by default `<leader>l`
 
 create_multiline_comment()					*gitlab.nvim.create_multiline_comment*
@@ -640,17 +640,17 @@ mode, and will use the currently selected lines.
 >lua
   require("gitlab").create_multiline_comment()
 
-Afer the comment is typed, submit it to Gitlab via the |settings.popup.perform_linewise_action|
-keybinding, by default `<leader>l` 
+After the comment is typed, submit it to Gitlab via the |settings.popup.perform_linewise_action|
+keybinding, by default `<leader>l`.
 
 create_comment_suggestion()					*gitlab.nvim.create_comment_suggestion*
 
-Opens a popup to create a comment suggestion (aka a comment that makes a committable 
-change suggestion to the currently selected lines). 
+Opens a popup to create a comment suggestion (aka a comment that makes a committable
+change suggestion to the currently selected lines).
 >lua
   require("gitlab").create_multiline_comment()
 
-Afer the comment is typed, submit it to Gitlab via the |settings.popup.perform_linewise_action|
+After the comment is typed, submit it to Gitlab via the |settings.popup.perform_linewise_action|
 keybinding, by default |<leader>l|
 
 create_mr({opts})						*gitlab.nvim.create_mr*
@@ -661,7 +661,7 @@ Starts the process of creating an MR for the currently checked out branch.
     require("gitlab").create_mr({ target = "main" })
     require("gitlab").create_mr({ target = "main", template_file = "my-template.md" })
 
-Parameters:  
+Parameters:
   • {opts}         Lua table that can be used to skip certain steps in the MR
   creation process. If `target` is provided, you will not be prompted for one.
   If a template_file is provided, it will be used automatically. Must be
@@ -680,12 +680,12 @@ If there are no diagnostics for the current line, shows a warning message.
 
 gitlab.create_note()						*gitlab.nvim.create_note*
 
-Opens a popup to create a note. Notes are like commments except they are not
+Opens a popup to create a note. Notes are like comments except they are not
 tied to specific changes in an MR.
 >lua
   require("gitlab").create_note()
 
-Afer the comment is typed, submit it to Gitlab via the |settings.popup.perform_action|
+After the comment is typed, submit it to Gitlab via the |settings.popup.perform_action|
 keybinding, by default |<leader>l|
 
 gitlab.toggle_discussions()					*gitlab.nvim.toggle_discussions*
@@ -694,8 +694,8 @@ Toggles visibility of the discussion tree.
 >lua
   require("gitlab").toggle_discussions()
 
-Once the discussion tree is open, a number of different keybindings are available 
-for interacting with different discussions. Please see the `settings.discussion_tree` 
+Once the discussion tree is open, a number of different keybindings are available
+for interacting with different discussions. Please see the `settings.discussion_tree`
 section of the setup call for more information about different keybindings.
 
 gitlab.add_assignee()						*gitlab.nvim.add_assignee*
@@ -740,7 +740,7 @@ Opens up a popup with information about the pipeline for the current merge reque
 >lua
   require("gitlab").pipeline()
 
-To re-trigger failed jobs in the pipeline manually, use the `settings.popup.perform_action` keybinding. 
+To re-trigger failed jobs in the pipeline manually, use the `settings.popup.perform_action` keybinding.
 To open the log trace of a job in a new Neovim buffer, use your `settings.popup.perform_linewise_action`
 keybinding.
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -354,6 +354,16 @@ delete/edit/reply are available on the note tree.
     require("gitlab").create_note()
 <
 
+When the 'wrap' option is on, line wrapping can make the discussion tree
+harder to read. You can use the 'breakindent' option to visually indent tree
+nodes at the same level. If you don't want to set 'breakindent' globally, you
+can set this only for the `gitlab` file type (the file type of discussions and
+notes). One way of doing this is by creating a file called
+$XDG_CONFIG_HOME/nvim/after/ftplugin/gitlab.lua with the following contents:
+>lua
+    vim.o.breakindent = true
+<
+
 LABELS			                     *gitlab.nvim.labels*
 
 You can add or remove labels from the current MR.

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -77,7 +77,7 @@ M.create_comment_suggestion = function()
   table.insert(suggestion_lines, backticks)
 
   comment_popup:mount()
-  vim.api.nvim_buf_set_lines(comment_popup.bufnr, 0, 0, false, suggestion_lines)
+  vim.api.nvim_buf_set_lines(comment_popup.bufnr, 0, -1, false, suggestion_lines)
   state.set_popup_keymaps(comment_popup, function(text)
     if range > 0 then
       M.confirm_create_comment(text, { start_line = start_line, end_line = end_line })

--- a/lua/gitlab/actions/create_mr.lua
+++ b/lua/gitlab/actions/create_mr.lua
@@ -259,10 +259,11 @@ end
 ---Builds a lua list of strings that contain the MR description
 M.build_description_lines = function(template_content)
   local description_lines = {}
-  for line in template_content:gmatch("[^\n]+") do
+  for line in u.split_by_new_lines(template_content) do
     table.insert(description_lines, line)
-    table.insert(description_lines, "")
   end
+  -- TODO: @harrisoncramer Same as in lua/gitlab/actions/summary.lua:114
+  table.insert(description_lines, "")
 
   return description_lines
 end

--- a/lua/gitlab/actions/discussions/tree.lua
+++ b/lua/gitlab/actions/discussions/tree.lua
@@ -92,7 +92,7 @@ end
 ---@return NuiTree.Node[]
 local function build_note_body(note, resolve_info)
   local text_nodes = {}
-  for bodyLine in note.body:gmatch("[^\n]+") do
+  for bodyLine in u.split_by_new_lines(note.body) do
     local line = attach_uuid(bodyLine)
     table.insert(
       text_nodes,

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -148,7 +148,7 @@ M.see_logs = function()
     end
 
     local lines = {}
-    for line in file:gmatch("[^\n]+") do
+    for line in u.split_by_new_lines(file) do
       table.insert(lines, line)
     end
 

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -108,10 +108,13 @@ M.build_description_lines = function()
   local description_lines = {}
 
   local description = state.INFO.description
-  for line in description:gmatch("[^\n]+") do
+  for line in u.split_by_new_lines(description) do
     table.insert(description_lines, line)
-    table.insert(description_lines, "")
   end
+  -- TODO: @harrisoncramer Not sure whether the following line should be here at all. It definitely
+  -- didn't belong into the for loop, since it inserted an empty line after each line. But maybe
+  -- there is a purpose for an empty line at the end of the buffer?
+  table.insert(description_lines, "")
 
   return description_lines
 end

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -148,6 +148,16 @@ M.trim = function(s)
   return res
 end
 
+---Splits a string by new lines and returns an iterator
+---@param s string The string to split
+---@return table: An iterator object
+M.split_by_new_lines = function(s)
+  if s:sub(-1) ~= "\n" then
+    s = s .. "\n"
+  end -- Append a new line to the string, if there's none, otherwise the last line would be lost.
+  return s:gmatch("(.-)\n") -- Match 0 or more (as few as possible) characters followed by a new line.
+end
+
 -- Reverses the order of elements in a list
 ---@param list table The list to reverse
 ---@return table


### PR DESCRIPTION
This MR addressed the issue that empty lines in discussion tree nodes were removed in `glab.nvim` even if the comment was created correctly on Gitlab. However, if a comment with deleted empty lines was edited in `glab.nvim` and saved again, the change was made also on Gitlab.

Apart from the main issue, this MR also fixes some problems with new lines in the MR summary and when creating a new MR. There is still an open question whether to remove even the last trailing new line in these two cases. A trailing new line is removed from the code suggestion.

Finally, a recommended setting regarding the display of discussion trees is added to, and some typos are removed from the `REAMDE.md`.

Closes #170