### PR TITLE
Feat: Make MR title input window configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ require("gitlab").setup({
   create_mr = {
     target = nil, -- Default branch to target when creating an MR
     template_file = nil, -- Default MR template in .gitlab/merge_request_templates
+    title_input = { -- Default settings for MR title input window
+      width = 40,
+      border = "rounded",
+    },
   },
   colors = {
     discussion_tree = {

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -246,6 +246,10 @@ you call this function with no values the defaults will be used:
       create_mr = {
         target = nil, -- Default branch to target when creating an MR
         template_file = nil, -- Default MR template in .gitlab/merge_request_templates
+        title_input = { -- Default settings for MR title input window
+          width = 40,
+          border = "rounded",
+        },
       },
       colors = {
         discussion_tree = {

--- a/lua/gitlab/actions/create_mr.lua
+++ b/lua/gitlab/actions/create_mr.lua
@@ -78,21 +78,6 @@ local description_popup_settings = {
   },
 }
 
----Create input options after user settings have been merged with defaults.
-local get_title_input_options = function()
-  return {
-    position = "50%",
-    relative = "editor",
-    size = state.settings.create_mr.title_input.width,
-    border = {
-      style = state.settings.create_mr.title_input.border,
-      text = {
-        top = "Title",
-      },
-    },
-  }
-end
-
 ---1. If the user has already begun writing an MR, prompt them to
 --- continue working on it.
 ---@param args? Args
@@ -189,7 +174,17 @@ end
 ---4. Prompts the user for the title of the MR
 ---@param mr Mr
 M.add_title = function(mr)
-  local input = Input(get_title_input_options(), {
+  local input = Input({
+    position = "50%",
+    relative = "editor",
+    size = state.settings.create_mr.title_input.width,
+    border = {
+      style = state.settings.create_mr.title_input.border,
+      text = {
+        top = "Title",
+      },
+    },
+  }, {
     prompt = "",
     default_value = "",
     on_close = function() end,

--- a/lua/gitlab/actions/create_mr.lua
+++ b/lua/gitlab/actions/create_mr.lua
@@ -78,17 +78,20 @@ local description_popup_settings = {
   },
 }
 
-local title_input_options = {
-  position = "50%",
-  relative = "editor",
-  size = 40,
-  border = {
-    style = "rounded",
-    text = {
-      top = "Title",
+---Create input options after user settings have been merged with defaults.
+local get_title_input_options = function()
+  return {
+    position = "50%",
+    relative = "editor",
+    size = state.settings.create_mr.title_input.width,
+    border = {
+      style = state.settings.create_mr.title_input.border,
+      text = {
+        top = "Title",
+      },
     },
-  },
-}
+  }
+end
 
 ---1. If the user has already begun writing an MR, prompt them to
 --- continue working on it.
@@ -186,7 +189,7 @@ end
 ---4. Prompts the user for the title of the MR
 ---@param mr Mr
 M.add_title = function(mr)
-  local input = Input(title_input_options, {
+  local input = Input(get_title_input_options(), {
     prompt = "",
     default_value = "",
     on_close = function() end,

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -81,6 +81,10 @@ M.settings = {
   create_mr = {
     target = nil,
     template_file = nil,
+    title_input = {
+      width = 40,
+      border = "rounded",
+    },
   },
   info = {
     enabled = true,


### PR DESCRIPTION
This mini PR makes it possible for users to configure the MR title input window.

It seems that "position" cannot be configured, but "size" is the most important anyway, to make writing long MR titles easier. Setting "border" is enabled just for UI consistency.