### PR TITLE
Fix: Line Comment Refactor

### DIFF
--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -112,7 +112,7 @@ end
 ---@field file_name string
 ---@field old_line integer | nil
 ---@field new_line integer | nil
----@field range_info ReviewerRangeInfo
+---@field range_info ReviewerRangeInfo|nil
 
 ---This function (settings.popup.perform_action) will send the comment to the Go server
 ---@param text string comment text

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -197,7 +197,7 @@ M.get_location = function(range)
     -- The line was not found in any hunks, only send the old line number
   elseif modification_type == "unmodified" or modification_type == "bad_file_unmodified" then
     reviewer_info.old_line = a_linenr
-    reviewer_info.new_line = a_linenr
+    reviewer_info.new_line = b_linenr
   end
 
   if range == nil then
@@ -339,17 +339,22 @@ end
 ---@param hunks Hunk[] A list of hunks
 ---@param all_diff_output table The raw diff output
 function M.get_modification_type(a_linenr, b_linenr, is_current_sha, hunks, all_diff_output)
-  -- If leaving a comment on the old window, we can either be commenting
-  -- on a deletion or an unmodified line. It's a deletion if it's in the range
-  -- of the hunks and the new range is zero, since that is only a deletion hunk,
-  -- or if we find a match in another hunk with a range, then we should check if that line
-  -- was actually deleted. To do that we have to see whether that line is prefixed
-  -- with a "-" only. If it is, then it's a deletion.
-  if not is_current_sha then
-    for _, hunk in ipairs(hunks) do
-      local old_line_end = hunk.old_line + hunk.old_range
-      local new_line_end = hunk.old_line + hunk.new_range
-      if a_linenr >= hunk.old_line and a_linenr <= old_line_end and hunk.new_range == 0 then
+  for _, hunk in ipairs(hunks) do
+    local old_line_end = hunk.old_line + hunk.old_range
+    local new_line_end = hunk.old_line + hunk.new_range
+
+    -- If leaving a comment on the old window, we can either be commenting
+    -- on a deletion or an unmodified line.
+    if is_current_sha then
+      if b_linenr >= hunk.new_line and b_linenr <= new_line_end - 1 then
+        return "added"
+      end
+    else
+      -- It's a deletion if it's in the range of the hunks and the new
+      -- range is zero, since that is only a deletion hunk, or if we find
+      -- a match in another hunk with a range, and the corresponding line is prefixed
+      -- with a "-" only. If it is, then it's a deletion.
+      if a_linenr >= hunk.old_line and a_linenr <= old_line_end and hunk.old_range == 0 then
         return "deleted"
       end
       if (a_linenr >= hunk.old_line and a_linenr <= old_line_end) or (a_linenr >= hunk.new_line and b_linenr <= new_line_end) then
@@ -358,23 +363,12 @@ function M.get_modification_type(a_linenr, b_linenr, is_current_sha, hunks, all_
         end
       end
     end
-    return "unmodified"
   end
 
-  -- If commenting in the newer file, same logic applies, but in reverse. Parse the lines
-  -- of output, if you are making a comment on a line that matches a hunk range for the new
-  -- line or an added line. The same logic applies as above: We need to parse all of the lines in
-  -- the hunk and see whether our line actually was added. It's added if
-  for _, hunk in ipairs(hunks) do
-    local new_line_end = hunk.new_line + hunk.new_range
-    if b_linenr >= hunk.new_line and b_linenr <= new_line_end - 1 then
-      return "added"
-    end
-  end
-
-  -- If we can't find the line, this means the user is trying to leave a comment on an unmodified
-  -- line, but in the new buffer. Warn them and do not post the comment.
-  return "bad_file_unmodified"
+  -- If we can't find the line, this means the user is either trying to leave
+  -- a comment on an unchanged line in the new or old file SHA. This is only
+  -- allowed in the old file
+  return is_current_sha and "bad_file_unmodified" or "unmodified"
 end
 
 ---@param a_linenr number
@@ -384,16 +378,11 @@ M.line_was_removed = function(a_linenr, hunk, all_diff_output)
   for matching_line_index, line in ipairs(all_diff_output) do
     local found_hunk = u.parse_possible_hunk_headers(line)
     if found_hunk ~= nil and vim.deep_equal(found_hunk, hunk) then
+      -- We found a matching hunk, now we need to iterate over the lines from the raw diff output
+      -- at that hunk until we reach the line we are looking for. When the indexes match we check
+      -- to see if that line is deleted or not.
       local j = 1
       for hunk_line_index = found_hunk.old_line, hunk.old_line + hunk.old_range - 1, 1 do
-        local line_content = all_diff_output[matching_line_index + j]
-        if hunk_line_index == a_linenr then
-          if string.match(line_content, "^%-") then
-            return "deleted"
-          end
-        end
-      end
-      for hunk_line_index = found_hunk.old_line, hunk.new_line + hunk.new_range - 1, 1 do
         local line_content = all_diff_output[matching_line_index + j]
         if hunk_line_index == a_linenr then
           if string.match(line_content, "^%-") then

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -410,12 +410,11 @@ M.line_was_added = function(linnr, hunk, all_diff_output)
   for matching_line_index, line in ipairs(all_diff_output) do
     local found_hunk = u.parse_possible_hunk_headers(line)
     if found_hunk ~= nil and vim.deep_equal(found_hunk, hunk) then
-      local index_from_new_lines_diff = found_hunk.new_line + 1 + found_hunk.old_range
-      local i = 0
       -- For added lines, we only want to iterate over the part of the diff that has has new lines,
       -- so we skip over the old range. We then keep track of the increment to the original new line index,
       -- and iterate until we reach the end of the total range of this hunk. If we arrive at the matching
       -- index for the line number, we check to see if the line was added.
+      local i = 0
       for hunk_line_index = matching_line_index + found_hunk.old_range + 1, matching_line_index + found_hunk.old_range + found_hunk.new_range, 1 do
         local line_content = all_diff_output[hunk_line_index]
         if (found_hunk.new_line + i) == linnr then

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -168,8 +168,6 @@ M.get_location = function(range)
   local a_win = u.get_window_id_by_buffer_id(layout.a.file.bufnr)
   local b_win = u.get_window_id_by_buffer_id(layout.b.file.bufnr)
 
-  vim.print("B window is " .. b_win)
-
   if a_win == nil or b_win == nil then
     u.notify("Error retrieving window IDs for current files", vim.log.levels.ERROR)
     return
@@ -179,7 +177,7 @@ M.get_location = function(range)
   local b_linenr = vim.api.nvim_win_get_cursor(b_win)[1]
   local current_bufnr = vim.api.nvim_get_current_buf()
 
-  local modification_type = M.get_modification_type(a_linenr)
+  local modification_type = M.get_modification_type(a_linenr, layout.a.file.path, nil)
 
   -- Comment on new line. Include only new_line in payload.
   if modification_type == "added" then

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -181,7 +181,7 @@ M.get_location = function(range)
 
   -- Will be different depending on focused window.
   local modification_type =
-      M.get_modification_type(a_linenr, b_linenr, is_current_sha, data.hunks, data.all_diff_output)
+    M.get_modification_type(a_linenr, b_linenr, is_current_sha, data.hunks, data.all_diff_output)
 
   if modification_type == "bad_file_unmodified" then
     u.notify("Comments on unmodified lines will be placed in the old file", vim.log.levels.WARN)
@@ -208,7 +208,7 @@ M.get_location = function(range)
   -- If leaving a multi-line comment, we want to also add range_info to the payload.
   local is_new = reviewer_info.new_line ~= nil
   local current_line_info = is_new and u.get_lines_from_hunks(data.hunks, reviewer_info.new_line, is_new)
-      or u.get_lines_from_hunks(data.hunks, reviewer_info.old_line, is_new)
+    or u.get_lines_from_hunks(data.hunks, reviewer_info.old_line, is_new)
   local type = is_new and "new" or "old"
 
   ---@type ReviewerRangeInfo
@@ -365,8 +365,8 @@ function M.get_modification_type(a_linenr, b_linenr, is_current_sha, hunks, all_
         return "deleted"
       end
       if
-          (a_linenr >= hunk.old_line and a_linenr <= old_line_end)
-          or (a_linenr >= hunk.new_line and b_linenr <= new_line_end)
+        (a_linenr >= hunk.old_line and a_linenr <= old_line_end)
+        or (a_linenr >= hunk.new_line and b_linenr <= new_line_end)
       then
         if M.line_was_removed(a_linenr, hunk, all_diff_output) then
           return "deleted"

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -180,7 +180,8 @@ M.get_location = function(range)
   end
 
   -- Will be different depending on focused window.
-  local modification_type = M.get_modification_type(a_linenr, b_linenr, is_current_sha, data.hunks, data.all_diff_output)
+  local modification_type =
+    M.get_modification_type(a_linenr, b_linenr, is_current_sha, data.hunks, data.all_diff_output)
 
   if modification_type == "bad_file_unmodified" then
     u.notify("Comments on unmodified lines will be placed in the old file", vim.log.levels.WARN)
@@ -206,8 +207,8 @@ M.get_location = function(range)
 
   -- If leaving a multi-line comment, we want to also add range_info to the payload.
   local is_new = reviewer_info.new_line ~= nil
-  local current_line_info = is_new and u.get_lines_from_hunks(data.hunks, reviewer_info.new_line, is_new) or
-      u.get_lines_from_hunks(data.hunks, reviewer_info.old_line, is_new)
+  local current_line_info = is_new and u.get_lines_from_hunks(data.hunks, reviewer_info.new_line, is_new)
+    or u.get_lines_from_hunks(data.hunks, reviewer_info.old_line, is_new)
   local type = is_new and "new" or "old"
 
   ---@type ReviewerRangeInfo
@@ -348,7 +349,9 @@ function M.get_modification_type(a_linenr, b_linenr, is_current_sha, hunks, all_
       -- or on an unmodified line. To tell, we have to check whether the line itself is
       -- prefixed with "+" and only return "added" if it is.
       if b_linenr >= hunk.new_line and b_linenr <= new_line_end then
-        if hunk.new_range == 0 then return "added" end
+        if hunk.new_range == 0 then
+          return "added"
+        end
         if M.line_was_added(b_linenr, hunk, all_diff_output) then
           return "added"
         end
@@ -361,7 +364,10 @@ function M.get_modification_type(a_linenr, b_linenr, is_current_sha, hunks, all_
       if a_linenr >= hunk.old_line and a_linenr <= old_line_end and hunk.old_range == 0 then
         return "deleted"
       end
-      if (a_linenr >= hunk.old_line and a_linenr <= old_line_end) or (a_linenr >= hunk.new_line and b_linenr <= new_line_end) then
+      if
+        (a_linenr >= hunk.old_line and a_linenr <= old_line_end)
+        or (a_linenr >= hunk.new_line and b_linenr <= new_line_end)
+      then
         if M.line_was_removed(a_linenr, hunk, all_diff_output) then
           return "deleted"
         end

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -181,7 +181,7 @@ M.get_location = function(range)
 
   -- Will be different depending on focused window.
   local modification_type =
-    M.get_modification_type(a_linenr, b_linenr, is_current_sha, data.hunks, data.all_diff_output)
+      M.get_modification_type(a_linenr, b_linenr, is_current_sha, data.hunks, data.all_diff_output)
 
   if modification_type == "bad_file_unmodified" then
     u.notify("Comments on unmodified lines will be placed in the old file", vim.log.levels.WARN)
@@ -208,7 +208,7 @@ M.get_location = function(range)
   -- If leaving a multi-line comment, we want to also add range_info to the payload.
   local is_new = reviewer_info.new_line ~= nil
   local current_line_info = is_new and u.get_lines_from_hunks(data.hunks, reviewer_info.new_line, is_new)
-    or u.get_lines_from_hunks(data.hunks, reviewer_info.old_line, is_new)
+      or u.get_lines_from_hunks(data.hunks, reviewer_info.old_line, is_new)
   local type = is_new and "new" or "old"
 
   ---@type ReviewerRangeInfo
@@ -365,8 +365,8 @@ function M.get_modification_type(a_linenr, b_linenr, is_current_sha, hunks, all_
         return "deleted"
       end
       if
-        (a_linenr >= hunk.old_line and a_linenr <= old_line_end)
-        or (a_linenr >= hunk.new_line and b_linenr <= new_line_end)
+          (a_linenr >= hunk.old_line and a_linenr <= old_line_end)
+          or (a_linenr >= hunk.new_line and b_linenr <= new_line_end)
       then
         if M.line_was_removed(a_linenr, hunk, all_diff_output) then
           return "deleted"
@@ -418,7 +418,7 @@ M.line_was_added = function(linnr, hunk, all_diff_output)
       -- index for the line number, we check to see if the line was added.
       for hunk_line_index = matching_line_index + found_hunk.old_range + 1, matching_line_index + found_hunk.old_range + found_hunk.new_range, 1 do
         local line_content = all_diff_output[hunk_line_index]
-        if (found_hunk.new_line + i) == index_from_new_lines_diff then
+        if (found_hunk.new_line + i) == linnr then
           if string.match(line_content, "^%+") then
             return "added"
           end

--- a/lua/gitlab/reviewer/diffview.lua
+++ b/lua/gitlab/reviewer/diffview.lua
@@ -381,9 +381,8 @@ M.line_was_removed = function(a_linenr, hunk, all_diff_output)
       -- We found a matching hunk, now we need to iterate over the lines from the raw diff output
       -- at that hunk until we reach the line we are looking for. When the indexes match we check
       -- to see if that line is deleted or not.
-      local j = 1
       for hunk_line_index = found_hunk.old_line, hunk.old_line + hunk.old_range - 1, 1 do
-        local line_content = all_diff_output[matching_line_index + j]
+        local line_content = all_diff_output[matching_line_index + 1]
         if hunk_line_index == a_linenr then
           if string.match(line_content, "^%-") then
             return "deleted"

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -154,7 +154,7 @@ end
 M.split_by_new_lines = function(s)
   if s:sub(-1) ~= "\n" then
     s = s .. "\n"
-  end -- Append a new line to the string, if there's none, otherwise the last line would be lost.
+  end                       -- Append a new line to the string, if there's none, otherwise the last line would be lost.
   return s:gmatch("(.-)\n") -- Match 0 or more (as few as possible) characters followed by a new line.
 end
 
@@ -197,7 +197,7 @@ M.format_to_local = function(date_string, offset)
     -- 2021-01-01T00:00:00.000-05:00
     local tzOffsetSign, tzOffsetHour, tzOffsetMin
     year, month, day, hour, min, sec, _, tzOffsetSign, tzOffsetHour, tzOffsetMin =
-      date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
+        date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
     tzOffset = tzOffsetSign .. tzOffsetHour .. tzOffsetMin
   end
 
@@ -463,12 +463,15 @@ M.get_line_content = function(bufnr, start)
   return lines[1]
 end
 
-M.get_win_from_buf = function(bufnr)
+M.get_wins_from_buf = function(bufnr)
+  local wins = {}
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     if vim.fn.winbufnr(win) == bufnr then
-      return win
+      table.insert(wins, win)
     end
   end
+
+  return wins
 end
 
 M.switch_can_edit_buf = function(buf, bool)

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -463,21 +463,28 @@ M.get_line_content = function(bufnr, start)
   return lines[1]
 end
 
-M.get_wins_from_buf = function(bufnr)
-  local wins = {}
-  for _, win in ipairs(vim.api.nvim_list_wins()) do
-    if vim.fn.winbufnr(win) == bufnr then
-      table.insert(wins, win)
-    end
-  end
-
-  return wins
-end
-
 M.switch_can_edit_buf = function(buf, bool)
   vim.api.nvim_set_option_value("modifiable", bool, { buf = buf })
   vim.api.nvim_set_option_value("readonly", not bool, { buf = buf })
 end
+
+-- Gets the window holding a buffer in the current tab page
+---@param buffer_id number Id of a buffer
+---@return integer|nil
+M.get_window_id_by_buffer_id = function(buffer_id)
+  local tabpage = vim.api.nvim_get_current_tabpage()
+  local windows = vim.api.nvim_tabpage_list_wins(tabpage)
+
+  for _, win_id in ipairs(windows) do
+    local buf_id = vim.api.nvim_win_get_buf(win_id)
+    if buf_id == buffer_id then
+      return win_id
+    end
+  end
+
+  return nil -- Buffer ID not found in any window
+end
+
 
 M.list_files_in_folder = function(folder_path)
   if vim.fn.isdirectory(folder_path) == 0 then

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -154,7 +154,7 @@ end
 M.split_by_new_lines = function(s)
   if s:sub(-1) ~= "\n" then
     s = s .. "\n"
-  end                       -- Append a new line to the string, if there's none, otherwise the last line would be lost.
+  end -- Append a new line to the string, if there's none, otherwise the last line would be lost.
   return s:gmatch("(.-)\n") -- Match 0 or more (as few as possible) characters followed by a new line.
 end
 
@@ -197,7 +197,7 @@ M.format_to_local = function(date_string, offset)
     -- 2021-01-01T00:00:00.000-05:00
     local tzOffsetSign, tzOffsetHour, tzOffsetMin
     year, month, day, hour, min, sec, _, tzOffsetSign, tzOffsetHour, tzOffsetMin =
-        date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
+      date_string:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).(%d+)([%+%-])(%d%d):(%d%d)")
     tzOffset = tzOffsetSign .. tzOffsetHour .. tzOffsetMin
   end
 
@@ -484,7 +484,6 @@ M.get_window_id_by_buffer_id = function(buffer_id)
 
   return nil -- Buffer ID not found in any window
 end
-
 
 M.list_files_in_folder = function(folder_path)
   if vim.fn.isdirectory(folder_path) == 0 then


### PR DESCRIPTION
This MR overhauls the logic that we previously had in place for determining payloads for creating comments.

Gitlab's API is notoriously awful when it comes to posting comments, because the actual content of the POST has to change depending on whether or not you are sending a comment on a modified line, an unchanged line, or a deleted line. 

This MR takes a very meticulous approach to determining what sort of change has occurred on the currently focused line. It does this by parsing the hunk headers and _actual content of the diff_ as well, to figure out whether the line has been added, changed, or untouched. It also takes advantage of Neovim's scroll lock functionality. If you are scrolling in the reviewer panel, the location of your cursor in the changed file and in the new file will be "locked" together. This let's us send not only the line in the current buffer (if you are in the new panel) but also the line number from the old buffer as well.

This MR is meant to resolve all issues with leaving single-line comments, as outlined in issue #128 

The plan is to keep this feature in a feature branch for some time and to have some users of the application make sure that it's working as intended. Once it's deemed stable enough it'll be merged into main.

THIS MR DOES NOT ATTEMPT TO ADDRESS OTHER ISSUES WITH MULTI-LINE COMMENTS.

There could still be issues with multi-line comments where the range is off for some reason. This MR will only fix all isues related to line codes being wrong.