### PR TITLE
Fix: Improve visibility of pipeline popup

### DIFF
--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -43,7 +43,7 @@ M.open = function()
     local height = 6 + #pipeline_jobs + 3
 
     local pipeline_popup =
-      Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height))
+      Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height, 60))
     M.pipeline_popup = pipeline_popup
     pipeline_popup:mount()
 


### PR DESCRIPTION
The pipeline popup can be shown on top of other popups, e.g., the summary or comment popups. When
the zindex of the pipeline popup is the same as that of the "lower" popup, its border is not
displayed correctly. This is fixed by increasing the zindex of the pipeline popup.