### PR TITLE
Fix toggle nodes not working properly after modifying notes

### DIFF
--- a/lua/gitlab/actions/discussions/annotations.lua
+++ b/lua/gitlab/actions/discussions/annotations.lua
@@ -84,6 +84,7 @@
 ---@field resolved_discussions number
 ---@field resolvable_notes number
 ---@field resolved_notes number
+---@field help_keymap string
 ---
 ---@class SignTable
 ---@field name string

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -40,12 +40,13 @@ local function content(discussions, unlinked_discussions, file_name)
     resolved_discussions = resolved_discussions,
     resolvable_notes = resolvable_notes,
     resolved_notes = resolved_notes,
+    help_keymap = state.settings.help,
   }
 
   return state.settings.discussion_tree.winbar(t)
 end
 
----This function sends the edited comment to the Go server
+---This function updates the winbar
 ---@param discussions Discussion[]
 ---@param unlinked_discussions UnlinkedDiscussion[]
 ---@param base_title string

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -169,6 +169,16 @@ M.settings = {
   },
 }
 
+-- These are the initial states of the discussion trees
+M.discussion_tree = {
+  resolved_expanded = false,
+  unresolved_expanded = false,
+}
+M.unlinked_discussion_tree = {
+  resolved_expanded = false,
+  unresolved_expanded = false,
+}
+
 -- Merges user settings into the default settings, overriding them
 M.merge_settings = function(args)
   M.settings = u.merge(M.settings, args)

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -79,7 +79,8 @@ M.settings = {
         discussions_content = "%#Comment#" .. discussions_content
         notes_content = "%#Text#" .. notes_content
       end
-      return " " .. discussions_content .. " %#Comment#| " .. notes_content
+      local help = "%#Comment#%=Help: " .. t.help_keymap:gsub(" ", "<space>") .. " "
+      return " " .. discussions_content .. " %#Comment#| " .. notes_content .. help
     end,
   },
   merge = {


### PR DESCRIPTION
Resolves #185.

Also makes the Help keymap visible in the discussion tree's winbar.