### PR TITLE
Feat: Improve discussion tree toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ require("gitlab").setup({
     resolved = '✓', -- Symbol to show next to resolved discussions
     unresolved = '-', -- Symbol to show next to unresolved discussions
     tree_type = "simple", -- Type of discussion tree - "simple" means just list of discussions, "by_file_name" means file tree with discussions under file
+    toggle_tree_type = "i", -- Toggle type of discussion tree - "simple", or "by_file_name"
     winbar = nil -- Custom function to return winbar title, should return a string. Provided with WinbarTable (defined in annotations.lua)
                  -- If using lualine, please add "gitlab" to disabled file types, otherwise you will not see the winbar.
   },

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -182,6 +182,7 @@ you call this function with no values the defaults will be used:
         resolved = '✓', -- Symbol to show next to resolved discussions
         unresolved = '-', -- Symbol to show next to unresolved discussions
         tree_type = "simple", -- Type of discussion tree - "simple" means just list of discussions, "by_file_name" means file tree with discussions under file
+        toggle_tree_type = "i", -- Toggle type of discussion tree - "simple", or "by_file_name"
         winbar = nil -- Custom function to return winbar title, should return a string. Provided with WinbarTable (defined in annotations.lua)
                      -- If using lualine, please add "gitlab" to disabled file types, otherwise you will not see the winbar.
       },

--- a/lua/gitlab/actions/discussions/annotations.lua
+++ b/lua/gitlab/actions/discussions/annotations.lua
@@ -84,6 +84,7 @@
 ---@field resolved_discussions number
 ---@field resolvable_notes number
 ---@field resolved_notes number
+---@field help_keymap string
 ---
 ---@class SignTable
 ---@field name string

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -75,8 +75,13 @@ M.refresh_discussion_data = function()
   end)
 end
 
----Toggle tree type between "simple" and "by_file_name"
-M.toggle_tree_type = function()
+---Toggle Discussions tree type between "simple" and "by_file_name"
+---@param unlinked boolean True if selected view type is Notes (unlinked discussions)
+M.toggle_tree_type = function(unlinked)
+  if unlinked then
+    u.notify("Toggling tree type is only possible in Discussions", vim.log.levels.INFO)
+    return
+  end
   if state.settings.discussion_tree.tree_type == "simple" then
     state.settings.discussion_tree.tree_type = "by_file_name"
   else
@@ -691,7 +696,7 @@ end
 
 M.set_tree_keymaps = function(tree, bufnr, unlinked)
   vim.keymap.set("n", state.settings.discussion_tree.toggle_tree_type, function()
-    M.toggle_tree_type()
+    M.toggle_tree_type(unlinked)
   end, { buffer = bufnr, desc = "Toggle tree type between `simple` and `by_file_name`" })
   vim.keymap.set("n", state.settings.discussion_tree.edit_comment, function()
     if M.is_current_node_note(tree) then

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -327,7 +327,15 @@ end
 -- This function (settings.discussion_tree.toggle_discussion_resolved) will toggle the resolved status of the current discussion and send the change to the Go server
 M.toggle_discussion_resolved = function(tree)
   local note = tree:get_node()
-  if not note or not note.resolvable then
+  if note == nil then
+    return
+  end
+
+  -- Switch to the root node to enable toggling from child nodes and note bodies
+  if not note.resolvable and M.is_node_note(note) then
+    note = M.get_root_node(tree, note)
+  end
+  if note == nil then
     return
   end
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -75,6 +75,16 @@ M.refresh_discussion_data = function()
   end)
 end
 
+---Toggle tree type between "simple" and "by_file_name"
+M.toggle_tree_type = function()
+  if state.settings.discussion_tree.tree_type == "simple" then
+    state.settings.discussion_tree.tree_type = "by_file_name"
+  else
+    state.settings.discussion_tree.tree_type = "simple"
+  end
+  M.rebuild_discussion_tree()
+end
+
 ---Opens the discussion tree, sets the keybindings. It also
 ---creates the tree for notes (which are not linked to specific lines of code)
 ---@param callback function?
@@ -680,6 +690,9 @@ M.is_current_node_note = function(tree)
 end
 
 M.set_tree_keymaps = function(tree, bufnr, unlinked)
+  vim.keymap.set("n", state.settings.discussion_tree.toggle_tree_type, function()
+    M.toggle_tree_type()
+  end, { buffer = bufnr, desc = "Toggle tree type between `simple` and `by_file_name`" })
   vim.keymap.set("n", state.settings.discussion_tree.edit_comment, function()
     if M.is_current_node_note(tree) then
       M.edit_comment(tree, unlinked)

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -370,6 +370,15 @@ M.toggle_node = function(tree)
   if node == nil then
     return
   end
+
+  -- Switch to the "note" node from "note_body" nodes to enable toggling discussions inside comments
+  if node.type == "note_body" then
+    node = tree:get_node(node:get_parent_id())
+  end
+  if node == nil then
+    return
+  end
+
   local children = node:get_child_ids()
   if node == nil then
     return

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -40,12 +40,13 @@ local function content(discussions, unlinked_discussions, file_name)
     resolved_discussions = resolved_discussions,
     resolvable_notes = resolvable_notes,
     resolved_notes = resolved_notes,
+    help_keymap = state.settings.help,
   }
 
   return state.settings.discussion_tree.winbar(t)
 end
 
----This function sends the edited comment to the Go server
+---This function updates the winbar
 ---@param discussions Discussion[]
 ---@param unlinked_discussions UnlinkedDiscussion[]
 ---@param base_title string

--- a/lua/gitlab/emoji.lua
+++ b/lua/gitlab/emoji.lua
@@ -70,7 +70,7 @@ M.init_popup = function(tree, bufnr)
   vim.api.nvim_create_autocmd({ "CursorHold" }, {
     callback = function()
       local node = tree:get_node()
-      if node == nil then
+      if node == nil or not require("gitlab.actions.discussions").is_node_note(node) then
         return
       end
 

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -79,7 +79,8 @@ M.settings = {
         discussions_content = "%#Comment#" .. discussions_content
         notes_content = "%#Text#" .. notes_content
       end
-      return " " .. discussions_content .. " %#Comment#| " .. notes_content
+      local help = "%#Comment#%=Help: " .. t.help_keymap:gsub(" ", "<space>") .. " "
+      return " " .. discussions_content .. " %#Comment#| " .. notes_content .. help
     end,
   },
   merge = {
@@ -167,6 +168,16 @@ M.settings = {
       unresolved = "DiagnosticSignWarn",
     },
   },
+}
+
+-- These are the initial states of the discussion trees
+M.discussion_tree = {
+  resolved_expanded = false,
+  unresolved_expanded = false,
+}
+M.unlinked_discussion_tree = {
+  resolved_expanded = false,
+  unresolved_expanded = false,
 }
 
 -- Merges user settings into the default settings, overriding them

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -64,6 +64,7 @@ M.settings = {
     resolved = "✓",
     unresolved = "-",
     tree_type = "simple",
+    toggle_tree_type = "i",
     ---@param t WinbarTable
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0


### PR DESCRIPTION
This PR tries to make toggling of the discussion tree a little more user friendly. It will:
- Enable toggling nodes from the note body
- Enable toggling resolved status from child nodes
- Add keymap for toggling tree type

Apart from that, it fixes a small bug which caused an error whenever the cursor moved to a `file_name` or `path` node in the "by_file_name" discussion tree.