### PR TITLE
fix: Calculate new line in ranged comment after all hunks correctly

### DIFF
--- a/lua/gitlab/hunks/init.lua
+++ b/lua/gitlab/hunks/init.lua
@@ -274,7 +274,7 @@ M.calculate_matching_line_new = function(old_sha, new_sha, file_path, line_numbe
   end
 
   -- TODO: Possibly handle lines that are out of range in the new files
-  return line_number
+  return line_number + net_change + 1
 end
 
 return M

--- a/lua/gitlab/indicators/signs.lua
+++ b/lua/gitlab/indicators/signs.lua
@@ -24,7 +24,7 @@ local severity_map = {
 ---@param diagnostics Diagnostic[]
 ---@param bufnr number
 M.set_signs = function(diagnostics, bufnr)
-  if not state.settings.discussion_sign.enabled then
+  if not state.settings.discussion_signs.enabled then
     return
   end
 


### PR DESCRIPTION
We were not returning the aggregated line changes when a comment fell after all hunks in the new SHA