### PR TITLE
fix: correcting some problem with review mode

### DIFF
--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -398,11 +398,11 @@ local function get_new_line(node)
 
   ---@type GitlabLineRange|nil
   local range = node.range
-  if range == nil then
-    if node.new_line == nil then
+  if range ~= nil then
+    if range.start.new_line == nil then
       return nil
     end
-    return node.new_line
+    return range.start.new_line
   end
 
   local start_new_line, _ = common.parse_line_code(range.start.line_code)

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -392,16 +392,13 @@ end
 ---@param node any
 ---@return number|nil
 local function get_new_line(node)
-  if node.new_line == nil then
-    return nil
-  end
-
   ---@type GitlabLineRange|nil
   local range = node.range
-  if range ~= nil then
-    if range.start.new_line == nil then
-      return nil
-    end
+  if range == nil then
+    return node.new_line
+  end
+
+  if range.start.new_line == nil then
     return range.start.new_line
   end
 
@@ -414,17 +411,17 @@ end
 ---@param node any
 ---@return number|nil
 local function get_old_line(node)
-  if node.old_line == nil then
-    return nil
-  end
-
   ---@type GitlabLineRange|nil
   local range = node.range
   if range == nil then
     return node.old_line
   end
 
-  local _, start_old_line = common.parse_line_code(range.start.line_code)
+  if range.start.old_line == nil then
+    return range.start.old_line
+  end
+
+  local start_old_line, _ = common.parse_line_code(range.start.line_code)
   return start_old_line
 end
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -405,7 +405,7 @@ local function get_new_line(node)
     return range.start.new_line
   end
 
-  local start_new_line, _ = common.parse_line_code(range.start.line_code)
+  local _, start_new_line = common.parse_line_code(range.start.line_code)
   return start_new_line
 end
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -453,7 +453,7 @@ M.jump_to_file = function(tree)
   if line_number == nil then
     line_number = 1
   end
-  local bufnr = vim.fn.bufnr(root_node.filename)
+  local bufnr = vim.fn.bufnr(root_node.file_name)
   if bufnr ~= -1 then
     vim.cmd("buffer " .. bufnr)
     vim.api.nvim_win_set_cursor(0, { line_number, 0 })
@@ -461,7 +461,7 @@ M.jump_to_file = function(tree)
   end
 
   -- If buffer is not already open, open it
-  vim.cmd("edit " .. root_node.filename)
+  vim.cmd("edit " .. root_node.file_name)
   vim.api.nvim_win_set_cursor(0, { line_number, 0 })
 end
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -398,7 +398,7 @@ local function get_new_line(node)
     return node.new_line
   end
 
-  if range.start.new_line == nil then
+  if range.start.new_line ~= nil then
     return range.start.new_line
   end
 
@@ -417,7 +417,7 @@ local function get_old_line(node)
     return node.old_line
   end
 
-  if range.start.old_line == nil then
+  if range.start.old_line ~= nil then
     return range.start.old_line
   end
 


### PR DESCRIPTION
Trying to fix some problem in the review command of the plugin, as describe in [this github discussion](https://github.com/harrisoncramer/gitlab.nvim/discussions/221).

It concern mainly the following problems:
- ```terminal
  Error executing lua: Vim:E5300: Expected a Number or a String
  stack traceback:
	[C]: in function 'bufnr'
	...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:456: in function 'jump_to_file'
	...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:832: in function <...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:830>
  ```
- ```
  E5108: Error executing lua: ...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:467: Cursor position outside buffer
  stack traceback:
  	[C]: in function 'nvim_win_set_cursor'
  	...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:467: in function 'jump_to_file'
  	...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:834: in function <...lazy/gitlab.nvim/lua/gitlab/actions/discussions/init.lua:832>
  ```