### PR TITLE
fix: diagnostic creation for comments on deleted lines

### DIFF
--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -49,7 +49,7 @@ end
 local create_single_line_diagnostic = function(discussion)
   local first_note = discussion.notes[1]
   return create_diagnostic({
-    lnum = first_note.position.new_line - 1,
+    lnum = (first_note.position.new_line or first_note.position.old_line) - 1,
   }, discussion)
 end
 


### PR DESCRIPTION
Fixes an issue where diagnostics were not created properly when the diagnostic was on a deleted line