### PR TITLE
Feat: Allow saving popup contents to temp_registers when quitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ require("gitlab").setup({
     pipeline = nil,
     reply = nil,
     squash_message = nil,
-    temp_registers = {},
+    temp_registers = {}, -- List of registers for backing up popup content (see `:h gitlab.nvim.temp-registers`)
   },
   discussion_tree = { -- The discussion tree that holds all comments
     auto_open = true, -- Automatically open when the reviewer is opened

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ require("gitlab").setup({
     pipeline = nil,
     reply = nil,
     squash_message = nil,
+    temp_registers = {},
   },
   discussion_tree = { -- The discussion tree that holds all comments
     auto_open = true, -- Automatically open when the reviewer is opened

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -152,7 +152,7 @@ you call this function with no values the defaults will be used:
         pipeline = nil,
         reply = nil,
         squash_message = nil,
-        temp_registers = {},
+        temp_registers = {}, -- List of registers for backing up popup content (see `:h gitlab.nvim.temp-registers`)
       },
       discussion_tree = { -- The discussion tree that holds all comments
         auto_open = true, -- Automatically open when the reviewer is opened

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -152,6 +152,7 @@ you call this function with no values the defaults will be used:
         pipeline = nil,
         reply = nil,
         squash_message = nil,
+        temp_registers = {},
       },
       discussion_tree = { -- The discussion tree that holds all comments
         auto_open = true, -- Automatically open when the reviewer is opened
@@ -290,6 +291,24 @@ code block with prefilled code from the visual selection.
 Just like the summary, all the different kinds of comments are saved via the
 `settings.popup.perform_action` keybinding.
 
+TEMPORARY REGISTERS                               *gitlab.nvim.temp-registers*
+
+While writing a note/comment/suggestion/reply, you may need to interrupt the
+work, do something else (e.g., read something in another file, etc.), and then
+get back to your work on the comment. For occasions like this, you can set
+`settings.popup.temp_registers` to a list of writable registers (see
+|registers|) to which the contents of the popup window will be saved just
+before quitting with the `settings.popup.exit` keybinding.
+
+A practical setting is, e.g., `settings.popup.backup_register = {'"', "g"}`
+which saves to the so called unnamed register (see |quotequote|) as well as to
+the "g" register. This lets you easily paste the text back in with |p| or |P|,
+or with `"gp` or `"gP` if the unnamed register gets overwritten with something
+else.
+
+NOTE: The `temp_registers` are also filled with the contents of the popup when
+pressing the `settings.popup.perform_action` keybinding, even if the action
+that was supposed to be performed fails.
 
 DISCUSSIONS AND NOTES                      *gitlab.nvim.discussions-and-notes*
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -11,6 +11,7 @@ Table of Contents                              *gitlab.nvim.table-of-contents*
   - Usage                                                  |gitlab.nvim.usage|
   - The Summary view                            |gitlab.nvim.the-summary-view|
   - Reviewing an MR                              |gitlab.nvim.reviewing-an-mr|
+  - Temporary registers                           |gitlab.nvim.temp-registers|
   - Discussions and Notes                  |gitlab.nvim.discussions-and-notes|
   - Labels                                                |gitlab.nvim.labels|
   - Signs and diagnostics                  |gitlab.nvim.signs-and-diagnostics|
@@ -296,15 +297,16 @@ TEMPORARY REGISTERS                               *gitlab.nvim.temp-registers*
 While writing a note/comment/suggestion/reply, you may need to interrupt the
 work, do something else (e.g., read something in another file, etc.), and then
 get back to your work on the comment. For occasions like this, you can set
-`settings.popup.temp_registers` to a list of writable registers (see
-|registers|) to which the contents of the popup window will be saved just
-before quitting with the `settings.popup.exit` keybinding.
+`settings.popup.temp_registers` to a list of writable registers (see |registers|)
+to which the contents of the popup window will be saved just before quitting.
 
-A practical setting is, e.g., `settings.popup.backup_register = {'"', "g"}`
-which saves to the so called unnamed register (see |quotequote|) as well as to
-the "g" register. This lets you easily paste the text back in with |p| or |P|,
+A possible setting is, e.g., `settings.popup.backup_register = {'"', "+", "g"}`
+which saves to the so called unnamed register (see |quotequote|), the system
+clipboard register (see |quoteplus|), as well as to the "g" register. This lets
+you easily paste the text back in with |p| or |P| (from the unnamed register),
 or with `"gp` or `"gP` if the unnamed register gets overwritten with something
-else.
+else. Using the clipboard register lets you easily use the text outside of
+nvim.
 
 NOTE: The `temp_registers` are also filled with the contents of the popup when
 pressing the `settings.popup.perform_action` keybinding, even if the action

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -35,7 +35,7 @@ M.create_comment = function()
   comment_popup:mount()
   state.set_popup_keymaps(comment_popup, function(text)
     M.confirm_create_comment(text)
-  end, miscellaneous.attach_file)
+  end, miscellaneous.attach_file, miscellaneous.editable_popup_opts)
 end
 
 ---Create multiline comment for the last selection.
@@ -48,7 +48,7 @@ M.create_multiline_comment = function()
   comment_popup:mount()
   state.set_popup_keymaps(comment_popup, function(text)
     M.confirm_create_comment(text, { start_line = start_line, end_line = end_line })
-  end, miscellaneous.attach_file)
+  end, miscellaneous.attach_file, miscellaneous.editable_popup_opts)
 end
 
 ---Create comment prepopulated with gitlab suggestion
@@ -95,7 +95,7 @@ M.create_comment_suggestion = function()
     else
       M.confirm_create_comment(text, nil)
     end
-  end, miscellaneous.attach_file)
+  end, miscellaneous.attach_file, miscellaneous.editable_popup_opts)
 end
 
 M.create_note = function()
@@ -103,7 +103,7 @@ M.create_note = function()
   note_popup:mount()
   state.set_popup_keymaps(note_popup, function(text)
     M.confirm_create_comment(text, nil, true)
-  end, miscellaneous.attach_file)
+  end, miscellaneous.attach_file, miscellaneous.editable_popup_opts)
 end
 
 ---This function (settings.popup.perform_action) will send the comment to the Go server

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -256,7 +256,12 @@ M.reply = function(tree)
   local discussion_node = M.get_root_node(tree, node)
   local id = tostring(discussion_node.id)
   reply_popup:mount()
-  state.set_popup_keymaps(reply_popup, M.send_reply(tree, id), miscellaneous.attach_file)
+  state.set_popup_keymaps(
+    reply_popup,
+    M.send_reply(tree, id),
+    miscellaneous.attach_file,
+    miscellaneous.editable_popup_opts
+  )
 end
 
 -- This function will send the reply to the Go API
@@ -331,7 +336,9 @@ M.edit_comment = function(tree, unlinked)
   vim.api.nvim_buf_set_lines(currentBuffer, 0, -1, false, lines)
   state.set_popup_keymaps(
     edit_popup,
-    M.send_edits(tostring(root_node.id), tonumber(note_node.root_note_id or note_node.id), unlinked)
+    M.send_edits(tostring(root_node.id), tonumber(note_node.root_note_id or note_node.id), unlinked),
+    nil,
+    miscellaneous.editable_popup_opts
   )
 end
 

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -3,6 +3,7 @@ local Popup = require("nui.popup")
 local state = require("gitlab.state")
 local job = require("gitlab.job")
 local reviewer = require("gitlab.reviewer")
+local miscellaneous = require("gitlab.actions.miscellaneous")
 
 local M = {}
 
@@ -33,7 +34,7 @@ M.merge = function(opts)
     squash_message_popup:mount()
     state.set_popup_keymaps(squash_message_popup, function(text)
       M.confirm_merge(merge_body, text)
-    end)
+    end, nil, miscellaneous.editable_popup_opts)
   else
     M.confirm_merge(merge_body)
   end

--- a/lua/gitlab/actions/miscellaneous.lua
+++ b/lua/gitlab/actions/miscellaneous.lua
@@ -34,4 +34,17 @@ M.attach_file = function()
   end)
 end
 
+-- Perform actions when exiting an editable popup (e.g., notes, comment, reply popups).
+local function exit_editable_popup()
+  -- Save the popup contents to `temp_registers`.
+  for _, register in ipairs(state.settings.popup.temp_registers) do
+    vim.cmd("silent 0,$yank " .. register)
+  end
+end
+
+M.editable_popup_opts = {
+  cb = exit_editable_popup,
+  action_before_exit = true,
+}
+
 return M

--- a/lua/gitlab/actions/miscellaneous.lua
+++ b/lua/gitlab/actions/miscellaneous.lua
@@ -34,17 +34,8 @@ M.attach_file = function()
   end)
 end
 
--- Perform actions when exiting an editable popup (e.g., notes, comment, reply popups).
-local function exit_editable_popup()
-  -- Save the popup contents to `temp_registers`.
-  for _, register in ipairs(state.settings.popup.temp_registers) do
-    vim.cmd("silent 0,$yank " .. register)
-  end
-end
-
 M.editable_popup_opts = {
-  cb = exit_editable_popup,
-  action_before_exit = true,
+  save_to_temp_register = true,
 }
 
 return M

--- a/lua/gitlab/emoji.lua
+++ b/lua/gitlab/emoji.lua
@@ -85,9 +85,14 @@ M.init_popup = function(tree, bufnr)
       end
 
       local cursor_pos = vim.api.nvim_win_get_cursor(0)
+      -- "zyiw on the next line erases the unnamed register. This may interfere with the
+      -- `temp_registers` used for backing up editable popup contents, so let's backup the unnamed
+      -- register.
+      local unnamed_register_contents = vim.fn.getreg('"')
       vim.api.nvim_command('normal! "zyiw')
       vim.api.nvim_win_set_cursor(0, cursor_pos)
       local word = vim.fn.getreg("z")
+      vim.fn.setreg('"', unnamed_register_contents) -- restore the unnamed register
 
       for k, v in pairs(M.emoji_map) do
         if v.moji == word then

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -297,7 +297,7 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
     end, { buffer = popup.bufnr, desc = "Perform linewise action" })
   end
 
-  vim.api.nvim_create_autocmd("BufUnload", {
+  vim.api.nvim_create_autocmd("BufWinLeave", {
     buffer = popup.bufnr,
     callback = function()
       if opts.save_to_temp_register then

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -39,6 +39,7 @@ M.settings = {
     help = nil,
     pipeline = nil,
     squash_message = nil,
+    temp_registers = {},
   },
   discussion_tree = {
     auto_open = true,

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -300,6 +300,12 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
   vim.api.nvim_create_autocmd("BufUnload", {
     buffer = popup.bufnr,
     callback = function()
+      if opts.save_to_temp_register then
+        local text = u.get_buffer_text(popup.bufnr)
+        for _, register in ipairs(M.settings.popup.temp_registers) do
+          vim.fn.setreg(register, text)
+        end
+      end
       exit(popup, opts)
     end,
   })


### PR DESCRIPTION
This MR addresses #177. The user can now specify a list of registers in `settings.popup.temp_registers` to which the contents of editable popups will be saved when exiting the popup.

A couple of notes on things that might be done differently:
1. If no `temp_registers` are defined, nothing happens. Instead, when quitting a popup without a temp_register being set, the user could be notified about the possibility as mentioned in the original feature request #177.
2. The `temp_registers` are filled even when triggering `settings.popup.perform_action` because this also triggers the `exit` function with the callback `lua/gitlab/state.lua:259` that does the popup saving. If this behaviour is undesirable, the `popup_opts` could be extended to make it possible not to save upon `perform_action`. However, I find this to be a nice side effect to the main purpose of `temp_registers`, as it makes it possible to get rid of the `backup_register` hotfix.