### PR TITLE
fix: deprecate backup register

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ require("gitlab").setup({
     pipeline = nil,
     reply = nil,
     squash_message = nil,
-    backup_register = nil,
   },
   discussion_tree = { -- The discussion tree that holds all comments
     auto_open = true, -- Automatically open when the reviewer is opened

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -159,7 +159,6 @@ you call this function with no values the defaults will be used:
         pipeline = nil,
         reply = nil,
         squash_message = nil,
-        backup_register = nil,
       },
       discussion_tree = { -- The discussion tree that holds all comments
         auto_open = true, -- Automatically open when the reviewer is opened
@@ -304,22 +303,6 @@ window with Gitlab’s suggest changes
 code block with prefilled code from the visual selection.
 Just like the summary, all the different kinds of comments are saved via the
 `settings.popup.perform_action` keybinding.
-
-BACKUP REGISTER                                  *gitlab.nvim.backup-register*
-
-Sometimes, the action triggered by `settings.popup.perform_action` can fail.
-To prevent losing your carefully crafted note/comment/suggestion you can set
-`settings.popup.backup_register` to a writable register (see |registers|) to
-which the contents of the popup window will be saved just before the action is
-performed. A practical setting is `settings.popup.backup_register = "+"` which
-saves to the system clipboard (see |quoteplus|). This lets you easily apply
-the action on Gitlab in a browser, if it keeps failing in `gitlab.nvim`.
-
-If you experience such problems, please first read the
-|gitlab.nvim.troubleshooting| section. If it does not help, see if there are
-any relevant known <https://github.com/harrisoncramer/gitlab.nvim/issues>. If
-there are none, please open one and provide any error messages that
-`gitlab.nvim` may be showing.
 
 DISCUSSIONS AND NOTES                      *gitlab.nvim.discussions-and-notes*
 

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -40,7 +40,6 @@ M.settings = {
     help = nil,
     pipeline = nil,
     squash_message = nil,
-    backup_register = nil,
   },
   discussion_tree = {
     auto_open = true,
@@ -283,9 +282,6 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
   if action ~= nil then
     vim.keymap.set("n", M.settings.popup.perform_action, function()
       local text = u.get_buffer_text(popup.bufnr)
-      if M.settings.popup.backup_register ~= nil then
-        vim.cmd("0,$yank " .. M.settings.popup.backup_register)
-      end
       if opts.action_before_close then
         action(text, popup.bufnr)
         exit(popup, opts)


### PR DESCRIPTION
This MR deprecates the "backup" register which was a hot-fix used to deal with bugs upon comment and note creation