### PR TITLE
feat: enable pipeline command on main/master

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -86,10 +86,6 @@ func GetCurrentBranchNameFromNativeGitCmd() (res string, e error) {
 
 	branchName := strings.TrimSpace(string(output))
 
-	if branchName == "main" || branchName == "master" {
-		return "", fmt.Errorf("Cannot run on %s branch", branchName)
-	}
-
 	return branchName, nil
 }
 

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -50,12 +50,17 @@ func (a *api) GetPipelineAndJobs(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
-		handleError(w, err, "Could not get latest pipeline", http.StatusInternalServerError)
+		handleError(w, err, fmt.Sprintf("Gitlab failed to get latest pipeline for %s branch", a.gitInfo.BranchName), http.StatusInternalServerError)
 		return
 	}
 
 	if res.StatusCode >= 300 {
-		handleError(w, GenericError{endpoint: "/pipeline"}, "Could not get latest pipeline", res.StatusCode)
+		handleError(w, GenericError{endpoint: "/pipeline"}, fmt.Sprintf("Could not get latest pipeline for %s branch", a.gitInfo.BranchName), res.StatusCode)
+		return
+	}
+
+	if pipeline == nil {
+		handleError(w, GenericError{endpoint: "/pipeline"}, fmt.Sprintf("No pipeline found for %s branch", a.gitInfo.BranchName), res.StatusCode)
 		return
 	}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -132,11 +132,12 @@ func createRouterAndApi(client ClientInterface, optFuncs ...optFunc) (*http.Serv
 	m.HandleFunc("/mr/revoke", a.withMr(a.revokeHandler))
 	m.HandleFunc("/mr/awardable/note/", a.withMr(a.emojiNoteHandler))
 
+	m.HandleFunc("/pipeline", a.pipelineHandler)
+	m.HandleFunc("/pipeline/trigger/", a.pipelineHandler)
 	m.HandleFunc("/users/me", a.meHandler)
 	m.HandleFunc("/attachment", a.attachmentHandler)
 	m.HandleFunc("/create_mr", a.createMr)
 	m.HandleFunc("/job", a.jobHandler)
-	m.HandleFunc("/pipeline/", a.pipelineHandler)
 	m.HandleFunc("/project/members", a.projectMembersHandler)
 	m.HandleFunc("/shutdown", a.shutdownHandler)
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -35,6 +35,7 @@ type fakeClient struct {
 	listAllProjectMembers              func(pid interface{}, opt *gitlab.ListProjectMembersOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectMember, *gitlab.Response, error)
 	retryPipelineBuild                 func(pid interface{}, pipeline int, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error)
 	listPipelineJobs                   func(pid interface{}, pipelineID int, opts *gitlab.ListJobsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Job, *gitlab.Response, error)
+	getLatestPipeline                  func(pid interface{}, opt *gitlab.GetLatestPipelineOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error)
 	getTraceFile                       func(pid interface{}, jobID int, options ...gitlab.RequestOptionFunc) (*bytes.Reader, *gitlab.Response, error)
 	listLabels                         func(pid interface{}, opt *gitlab.ListLabelsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Label, *gitlab.Response, error)
 	listMergeRequestAwardEmojiOnNote   func(pid interface{}, mergeRequestIID, noteID int, opt *gitlab.ListAwardEmojiOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.AwardEmoji, *gitlab.Response, error)
@@ -118,6 +119,10 @@ func (f fakeClient) RetryPipelineBuild(pid interface{}, pipeline int, options ..
 
 func (f fakeClient) ListPipelineJobs(pid interface{}, pipelineID int, opts *gitlab.ListJobsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Job, *gitlab.Response, error) {
 	return f.listPipelineJobs(pid, pipelineID, opts, options...)
+}
+
+func (f fakeClient) GetLatestPipeline(pid interface{}, opts *gitlab.GetLatestPipelineOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error) {
+	return f.getLatestPipeline(pid, opts, options...)
 }
 
 func (f fakeClient) GetTraceFile(pid interface{}, jobID int, options ...gitlab.RequestOptionFunc) (*bytes.Reader, *gitlab.Response, error) {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -53,6 +53,7 @@ type ClientInterface interface {
 	ListAllProjectMembers(pid interface{}, opt *gitlab.ListProjectMembersOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectMember, *gitlab.Response, error)
 	RetryPipelineBuild(pid interface{}, pipeline int, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error)
 	ListPipelineJobs(pid interface{}, pipelineID int, opts *gitlab.ListJobsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Job, *gitlab.Response, error)
+	GetLatestPipeline(pid interface{}, opt *gitlab.GetLatestPipelineOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error)
 	GetTraceFile(pid interface{}, jobID int, options ...gitlab.RequestOptionFunc) (*bytes.Reader, *gitlab.Response, error)
 	ListLabels(pid interface{}, opt *gitlab.ListLabelsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Label, *gitlab.Response, error)
 	ListMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID int, noteID int, opt *gitlab.ListAwardEmojiOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.AwardEmoji, *gitlab.Response, error)

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -10,7 +10,7 @@ local M = {
   pipeline_popup = nil,
 }
 
-local function get_pipeline()
+local function get_latest_pipeline()
   local pipeline = state.INFO.head_pipeline or state.INFO.pipeline
 
   if type(pipeline) ~= "table" or (type(pipeline) == "table" and u.table_size(pipeline) == 0) then
@@ -21,7 +21,7 @@ local function get_pipeline()
 end
 
 M.get_pipeline_status = function()
-  local pipeline = get_pipeline()
+  local pipeline = get_latest_pipeline()
   if pipeline == nil then
     return nil
   end
@@ -30,7 +30,7 @@ end
 
 -- The function will render the Pipeline state in a popup
 M.open = function()
-  local pipeline = get_pipeline()
+  local pipeline = get_latest_pipeline()
   if not pipeline then
     return
   end
@@ -43,7 +43,7 @@ M.open = function()
     local height = 6 + #pipeline_jobs + 3
 
     local pipeline_popup =
-      Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height, 60))
+        Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height, 60))
     M.pipeline_popup = pipeline_popup
     pipeline_popup:mount()
 
@@ -101,7 +101,7 @@ M.open = function()
 end
 
 M.retrigger = function()
-  local pipeline = get_pipeline()
+  local pipeline = get_latest_pipeline()
   if not pipeline then
     return
   end

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -44,7 +44,7 @@ M.open = function()
   local height = 6 + #M.pipeline_jobs + 3
 
   local pipeline_popup =
-      Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height, 60))
+    Popup(u.create_popup_state("Loading Pipeline...", state.settings.popup.pipeline, width, height, 60))
   M.pipeline_popup = pipeline_popup
   pipeline_popup:mount()
 

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -12,7 +12,7 @@ local M = {
 }
 
 local function get_latest_pipeline()
-  local pipeline = state.PIPELINE.latest_pipeline
+  local pipeline = state.PIPELINE and state.PIPELINE.latest_pipeline
   if type(pipeline) ~= "table" or (type(pipeline) == "table" and u.table_size(pipeline) == 0) then
     u.notify("Pipeline not found", vim.log.levels.WARN)
     return

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -21,15 +21,19 @@ local function get_latest_pipeline()
 end
 
 local function get_pipeline_jobs()
+  M.latest_pipeline = get_latest_pipeline()
+  if not M.latest_pipeline then
+    return
+  end
   return u.reverse(type(state.PIPELINE.jobs) == "table" and state.PIPELINE.jobs or {})
 end
 
 M.get_pipeline_status = function()
-  local pipeline = get_latest_pipeline()
-  if pipeline == nil then
-    return nil
+  M.latest_pipeline = get_latest_pipeline()
+  if not M.latest_pipeline then
+    return
   end
-  return string.format("%s (%s)", state.settings.pipeline[pipeline.status], pipeline.status)
+  return string.format("%s (%s)", state.settings.pipeline[M.latest_pipeline.status], M.latest_pipeline.status)
 end
 
 -- The function will render the Pipeline state in a popup

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -8,7 +8,6 @@ local u = require("gitlab.utils")
 local List = require("gitlab.utils.list")
 local state = require("gitlab.state")
 local miscellaneous = require("gitlab.actions.miscellaneous")
-local pipeline = require("gitlab.actions.pipeline")
 
 local M = {
   layout_visible = false,
@@ -139,7 +138,11 @@ M.build_info_lines = function()
     pipeline = {
       title = "Pipeline Status",
       content = function()
-        return pipeline.get_pipeline_status()
+        local pipeline = state.INFO.pipeline
+        if type(pipeline) ~= "table" or (type(pipeline) == "table" and u.table_size(pipeline) == 0) then
+          return ""
+        end
+        return pipeline.status
       end,
     },
   }

--- a/lua/gitlab/async.lua
+++ b/lua/gitlab/async.lua
@@ -35,12 +35,6 @@ function async:fetch(dependencies, i, argTable)
     return
   end
 
-  -- If the dependency has a condition that is false, skip the API call
-  if dependency.condition == false then
-    self:fetch(dependencies, i + 1, argTable)
-    return
-  end
-
   -- Call the API, set the data, and then call the next API
   job.run_job(dependency.endpoint, "GET", dependency.body, function(data)
     state[dependency.state] = data[dependency.key]

--- a/lua/gitlab/async.lua
+++ b/lua/gitlab/async.lua
@@ -35,6 +35,12 @@ function async:fetch(dependencies, i, argTable)
     return
   end
 
+  -- If the dependency has a condition that is false, skip the API call
+  if dependency.condition == false then
+    self:fetch(dependencies, i + 1, argTable)
+    return
+  end
+
   -- Call the API, set the data, and then call the next API
   job.run_job(dependency.endpoint, "GET", dependency.body, function(data)
     state[dependency.state] = data[dependency.key]

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -19,6 +19,7 @@ local user = state.dependencies.user
 local info = state.dependencies.info
 local labels_dep = state.dependencies.labels
 local project_members = state.dependencies.project_members
+local pipeline_dep = state.dependencies.pipeline
 local revisions = state.dependencies.revisions
 
 return {
@@ -26,12 +27,12 @@ return {
     if args == nil then
       args = {}
     end
-    server.build() -- Builds the Go binary if it doesn't exist
-    state.merge_settings(args) -- Sets keymaps and other settings from setup function
-    require("gitlab.colors") -- Sets colors
+    server.build()                       -- Builds the Go binary if it doesn't exist
+    state.merge_settings(args)           -- Sets keymaps and other settings from setup function
+    require("gitlab.colors")             -- Sets colors
     reviewer.init()
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
-    emoji.init() -- Read in emojis for lookup purposes
+    emoji.init()                         -- Read in emojis for lookup purposes
   end,
   -- Global Actions 🌎
   summary = async.sequence({ u.merge(info, { refresh = true }), labels_dep }, summary.summary),
@@ -55,7 +56,7 @@ return {
   close_review = function()
     reviewer.close()
   end,
-  pipeline = async.sequence({ info }, pipeline.open),
+  pipeline = async.sequence({ pipeline_dep }, pipeline.open),
   merge = async.sequence({ u.merge(info, { refresh = true }) }, merge.merge),
   -- Discussion Tree Actions 🌴
   toggle_discussions = async.sequence({ info, user }, discussions.toggle),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -35,7 +35,11 @@ return {
     emoji.init() -- Read in emojis for lookup purposes
   end,
   -- Global Actions 🌎
-  summary = async.sequence({ u.merge(info, { refresh = true }), labels_dep }, summary.summary),
+  summary = async.sequence({
+    u.merge(info, { refresh = true }),
+    u.merge(labels_dep, { condition = u.contains(state.settings.info.fields, "labels") }),
+    u.merge(pipeline_dep, { condition = u.contains(state.settings.info.fields, "pipeline") }),
+  }, summary.summary),
   approve = async.sequence({ info }, approvals.approve),
   revoke = async.sequence({ info }, approvals.revoke),
   add_reviewer = async.sequence({ info, project_members }, assignees_and_reviewers.add_reviewer),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -27,12 +27,12 @@ return {
     if args == nil then
       args = {}
     end
-    server.build()                       -- Builds the Go binary if it doesn't exist
-    state.merge_settings(args)           -- Sets keymaps and other settings from setup function
-    require("gitlab.colors")             -- Sets colors
+    server.build() -- Builds the Go binary if it doesn't exist
+    state.merge_settings(args) -- Sets keymaps and other settings from setup function
+    require("gitlab.colors") -- Sets colors
     reviewer.init()
     discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
-    emoji.init()                         -- Read in emojis for lookup purposes
+    emoji.init() -- Read in emojis for lookup purposes
   end,
   -- Global Actions 🌎
   summary = async.sequence({ u.merge(info, { refresh = true }), labels_dep }, summary.summary),

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -37,8 +37,7 @@ return {
   -- Global Actions 🌎
   summary = async.sequence({
     u.merge(info, { refresh = true }),
-    u.merge(labels_dep, { condition = u.contains(state.settings.info.fields, "labels") }),
-    u.merge(pipeline_dep, { condition = u.contains(state.settings.info.fields, "pipeline") }),
+    labels_dep,
   }, summary.summary),
   approve = async.sequence({ info }, approvals.approve),
   revoke = async.sequence({ info }, approvals.revoke),

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -72,10 +72,10 @@ M.settings = {
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0
           and string.format("Discussions (%d/%d)", t.resolved_discussions, t.resolvable_discussions)
-          or "Discussions"
+        or "Discussions"
       local notes_content = t.resolvable_notes ~= 0
           and string.format("Notes (%d/%d)", t.resolved_notes, t.resolvable_notes)
-          or "Notes"
+        or "Notes"
       if t.name == "Discussions" then
         notes_content = "%#Comment#" .. notes_content
         discussions_content = "%#Text#" .. discussions_content

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -72,10 +72,10 @@ M.settings = {
     winbar = function(t)
       local discussions_content = t.resolvable_discussions ~= 0
           and string.format("Discussions (%d/%d)", t.resolved_discussions, t.resolvable_discussions)
-        or "Discussions"
+          or "Discussions"
       local notes_content = t.resolvable_notes ~= 0
           and string.format("Notes (%d/%d)", t.resolved_notes, t.resolvable_notes)
-        or "Notes"
+          or "Notes"
       if t.name == "Discussions" then
         notes_content = "%#Comment#" .. notes_content
         discussions_content = "%#Text#" .. discussions_content
@@ -314,6 +314,7 @@ end
 M.dependencies = {
   user = { endpoint = "/users/me", key = "user", state = "USER", refresh = false },
   info = { endpoint = "/mr/info", key = "info", state = "INFO", refresh = false },
+  pipeline = { endpoint = "/pipeline", key = "latest_pipeline", state = "PIPELINE", refresh = true },
   labels = { endpoint = "/mr/label", key = "labels", state = "LABELS", refresh = false },
   revisions = { endpoint = "/mr/revisions", key = "Revisions", state = "MR_REVISIONS", refresh = false },
   project_members = {


### PR DESCRIPTION
Addresses #218

This MR makes it possible to fetch the pipeline information on the main/master branch. It does so by removing the requirement that you open gitlab.nvim inside of a feature branch, and by making a call to [the latest pipeline for the current branch](https://docs.gitlab.com/ee/api/pipelines.html#get-the-latest-pipeline), rather than getting the pipeline ID from the "info" section of an MR.