### PR TITLE
Fix: Autocommand causes errors on MR creation

### DIFF
--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -280,9 +280,9 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
       local text = u.get_buffer_text(popup.bufnr)
       if opts.action_before_close then
         action(text, popup.bufnr)
-        exit(popup, opts)
+        vim.api.nvim_buf_delete(popup.bufnr, {})
       else
-        exit(popup, opts)
+        vim.api.nvim_buf_delete(popup.bufnr, {})
         action(text, popup.bufnr)
       end
     end, { buffer = popup.bufnr, desc = "Perform action" })


### PR DESCRIPTION
## Bug Description

The autocommand triggered on `BufWinLeave` still causes errors with unavailable buffers when pressing the `state.settings.popup.perform_linewise_action` keybinding in the Confirmation popup. This problem was there already with `BufUnload` because this keybinding is mapped to:
```lua
    vim.keymap.set("n", M.settings.popup.perform_action, function()
      local text = u.get_buffer_text(popup.bufnr)
      if opts.action_before_close then
        action(text, popup.bufnr)
        exit(popup, opts)
      else
        exit(popup, opts)
        action(text, popup.bufnr)
      end
    end, { buffer = popup.bufnr, desc = "Perform action" })
```
In this code block the `exit()` function is called (see bottom of message for full error traceback), which later calls `popup:unmount` and in turn `nvim_buf_delete` which triggers the `BufWinLeave` event, which causes the `exit()` function to be called once more on line 309 in `lua/gitlab/state.lua`.

When I use this instead, the problem seems to be gone, since we now let the `exit()` function only be called by the autocommand:
```diff
diff --git a/lua/gitlab/state.lua b/lua/gitlab/state.lua
index 6c15622..0b3b96c 100644
--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -280,9 +280,9 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
       local text = u.get_buffer_text(popup.bufnr)
       if opts.action_before_close then
         action(text, popup.bufnr)
-        exit(popup, opts)
+        vim.api.nvim_buf_delete(popup.bufnr, {})
       else
-        exit(popup, opts)
+        vim.api.nvim_buf_delete(popup.bufnr, {})
         action(text, popup.bufnr)
       end
     end, { buffer = popup.bufnr, desc = "Perform action" })
```

## Error traceback

```
Error detected while processing BufWinLeave Autocommands for "<buffer=19>":
Error executing lua callback: gitlab.nvim/lua/gitlab/utils/init.lua:345: Invalid buffer id: 13
stack traceback:
        [C]: in function 'nvim_buf_get_lines'
        gitlab.nvim/lua/gitlab/utils/init.lua:345: in function 'get_buffer_text'
        gitlab.nvim/lua/gitlab/actions/create_mr.lua:185: in function 'cb'
        gitlab.nvim/lua/gitlab/state.lua:257: in function 'exit'
        gitlab.nvim/lua/gitlab/state.lua:309: in function <gitlab.nvim/lua/gitlab/state.lua:302>
        [C]: in function 'nvim_buf_delete'
        ...b/.local/share/nvim/lazy/nui.nvim/lua/nui/popup/init.lua:298: in function '_buf_destroy'
        ...b/.local/share/nvim/lazy/nui.nvim/lua/nui/popup/init.lua:322: in function 'unmount'
        ....local/share/nvim/lazy/nui.nvim/lua/nui/layout/float.lua:164: in function 'unmount_box'
        ....local/share/nvim/lazy/nui.nvim/lua/nui/layout/float.lua:166: in function 'unmount_box'
        .../.local/share/nvim/lazy/nui.nvim/lua/nui/layout/init.lua:332: in function 'unmount'
        gitlab.nvim/lua/gitlab/actions/create_mr.lua:197: in function 'cb'
        gitlab.nvim/lua/gitlab/state.lua:257: in function 'exit'
        gitlab.nvim/lua/gitlab/state.lua:283: in function <gitlab.nvim/lua/gitlab/state.lua:279>
```