### PR TITLE
Fix: Cursor position beyond buffer end

### DIFF
--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -115,13 +115,19 @@ M.jump = function(file_name, line_number, new_buffer)
   async.await(view:set_file(file))
 
   local layout = view.cur_layout
+  local number_of_lines
   if new_buffer then
     layout.b:focus()
-    vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+    number_of_lines = u.get_buffer_length(layout.b.file.bufnr)
   else
     layout.a:focus()
-    vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+    number_of_lines = u.get_buffer_length(layout.a.file.bufnr)
   end
+  if line_number > number_of_lines then
+    u.notify("Diagnostic position outside buffer. Jumping to last line instead.", vim.log.levels.WARN)
+    line_number = number_of_lines
+  end
+  vim.api.nvim_win_set_cursor(0, { line_number, 0 })
 end
 
 ---Get the data from diffview, such as line information and file name. May be used by

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -347,6 +347,11 @@ M.get_buffer_text = function(bufnr)
   return text
 end
 
+---Returns the number of lines in the buffer. Returns 1 even for empty buffers.
+M.get_buffer_length = function(bufnr)
+  return #vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
 ---Convert string to corresponding boolean
 ---@param str string
 ---@return boolean


### PR DESCRIPTION
Hi @harrisoncramer, here's a fix for a similar problem that you solved today -- this time at the end of a file that has fewer lines, so `jump_to_reviewer` tries to jump past the last line of a buffer. Now, the cursor moves to the last line and a warning is shown, instead of throwing an error.