### PR TITLE
Fix: File comments don't have line number information

### DIFF
--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -49,7 +49,7 @@ end
 local create_single_line_diagnostic = function(discussion)
   local first_note = discussion.notes[1]
   return create_diagnostic({
-    lnum = (first_note.position.new_line or first_note.position.old_line) - 1,
+    lnum = (first_note.position.new_line or first_note.position.old_line or 1) - 1,
   }, discussion)
 end
 


### PR DESCRIPTION
Addresses #263. This is a simple fix, not sure whether the missing line number information for "file" comments should be handled in another place.