### PR TITLE
Fixes no draft notes, winbar issue

### DIFF
--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -51,7 +51,7 @@ M.add_empty_titles = function(title_args)
     vim.cmd("highlight default TitleHighlight guifg=#787878")
 
     -- Set empty title if applicable
-    if type(v.data) ~= "table" or #v.data == 0 then
+    if #v.data == 0 then
       vim.api.nvim_buf_set_lines(v.bufnr, 0, 1, false, { v.title })
       local linnr = 1
       vim.api.nvim_buf_set_extmark(

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -111,14 +111,6 @@ M.toggle = function(callback)
   state.DISCUSSION_DATA.unlinked_discussions = u.ensure_table(state.DISCUSSION_DATA.unlinked_discussions)
   state.DRAFT_NOTES = u.ensure_table(state.DRAFT_NOTES)
 
-  if #state.DISCUSSION_DATA.discussions + #state.DISCUSSION_DATA.unlinked_discussions + #state.DRAFT_NOTES == 0 then
-    u.notify("No discussions, notes, or draft notes for this MR", vim.log.levels.WARN)
-    if M.split ~= nil then
-      vim.api.nvim_buf_set_lines(M.split.bufnr, 0, -1, false, { "" })
-    end
-    return
-  end
-
   -- Make buffers, get and set buffer numbers, set filetypes
   local split, linked_bufnr, unlinked_bufnr = M.create_split_and_bufs()
   M.split = split

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -90,12 +90,11 @@ end
 
 --- Take existing data and refresh the diagnostics, the winbar, and the signs
 M.refresh_view = function()
-  if state.settings.discussion_signs.enabled and state.DISCUSSION_DATA then
+  if state.settings.discussion_signs.enabled then
     diagnostics.refresh_diagnostics()
   end
-  if M.split_visible and state.DISCUSSION_DATA then
-    winbar.update_winbar()
-  end
+  winbar.update_winbar()
+  common.add_empty_titles()
 end
 
 ---Opens the discussion tree, sets the keybindings. It also
@@ -135,26 +134,6 @@ M.toggle = function(callback)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unliked_bufnr)
   M.rebuild_discussion_tree()
   M.rebuild_unlinked_discussion_tree()
-
-  local position_drafts = List.new(state.DRAFT_NOTES):filter(function(note)
-    return draft_notes.has_position(note)
-  end)
-  local non_positioned_drafts = List.new(state.DRAFT_NOTES):filter(function(note)
-    return not draft_notes.has_position(note)
-  end)
-
-  common.add_empty_titles({
-    {
-      bufnr = M.linked_bufnr,
-      data = u.join(state.DISCUSSION_DATA.discussions, position_drafts),
-      title = "No Discussions for this MR",
-    },
-    {
-      bufnr = M.unlinked_bufnr,
-      data = u.join(state.DISCUSSION_DATA.unlinked_discussions or {}, non_positioned_drafts),
-      title = "No Notes (Unlinked Discussions) for this MR",
-    },
-  })
 
   -- Set default buffer
   local default_buffer = winbar.bufnr_map[state.settings.discussion_tree.default_view]

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -70,6 +70,9 @@ end
 ---This function updates the winbar
 M.update_winbar = function()
   local d = require("gitlab.actions.discussions")
+  if d.split == nil then
+    return
+  end
   local winId = d.split.winid
   local c = content()
   if vim.wo[winId] then

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -73,11 +73,18 @@ M.update_winbar = function()
   if d.split == nil then
     return
   end
-  local winId = d.split.winid
-  local c = content()
-  if vim.wo[winId] then
-    vim.wo[winId].winbar = c
+
+  local win_id = d.split.winid
+  if win_id == nil then
+    return
   end
+
+  if not vim.api.nvim_win_is_valid(win_id) then
+    return
+  end
+
+  local c = content()
+  vim.api.nvim_set_option_value("winbar", c, { scope = "local", win = win_id })
 end
 
 ---Builds the title string for both sections, using the count of resolvable and draft nodes

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -21,7 +21,7 @@ local M = {}
 ---Adds a draft note to the draft notes state, then rebuilds the view
 ---@param opts AddDraftNoteOpts
 M.add_draft_note = function(opts)
-  local new_draft_notes = state.DRAFT_NOTES
+  local new_draft_notes = u.ensure_table(state.DRAFT_NOTES)
   table.insert(new_draft_notes, opts.draft_note)
   state.DRAFT_NOTES = new_draft_notes
   local discussions = require("gitlab.actions.discussions")
@@ -153,6 +153,7 @@ M.send_deletion = function(tree)
     end
 
     winbar.update_winbar()
+    common.add_empty_titles()
   end)
 end
 

--- a/lua/gitlab/indicators/common.lua
+++ b/lua/gitlab/indicators/common.lua
@@ -31,12 +31,12 @@ end
 ---Filter all discussions which are relevant for currently visible signs and diagnostics.
 ---@return Discussion|DraftNote[]
 M.filter_placeable_discussions = function()
-  local discussions = state.DISCUSSION_DATA.discussions
+  local discussions = u.ensure_table(state.DISCUSSION_DATA and state.DISCUSSION_DATA.discussions or {})
   if type(discussions) ~= "table" then
     discussions = {}
   end
 
-  local draft_notes = state.DRAFT_NOTES
+  local draft_notes = u.ensure_table(state.DRAFT_NOTES)
   if type(draft_notes) ~= "table" then
     draft_notes = {}
   end

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -760,7 +760,7 @@ M.trim_slash = function(s)
 end
 
 M.ensure_table = function(data)
-  if data == vim.NIL then
+  if data == vim.NIL or data == nil then
     return {}
   end
   return data

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -759,4 +759,11 @@ M.trim_slash = function(s)
   return (s:gsub("/+$", ""))
 end
 
+M.ensure_table = function(data)
+  if data == vim.NIL then
+    return {}
+  end
+  return data
+end
+
 return M


### PR DESCRIPTION
Fixes a few different issues with empty states not refreshing properly and the winbar not refreshing properly when there is "no data" in a given discussion tree window pane.