### PR TITLE
fix: Fixes line number for diagnostics in old sha

### DIFF
--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -48,8 +48,9 @@ end
 ---@return Diagnostic
 local create_single_line_diagnostic = function(discussion)
   local first_note = discussion.notes[1]
+  local linnr = (common.is_new_sha(discussion) and first_note.position.new_line or first_note.position.old_line) or 1
   return create_diagnostic({
-    lnum = (first_note.position.new_line or first_note.position.old_line) - 1,
+    lnum = linnr - 1,
   }, discussion)
 end
 


### PR DESCRIPTION
We need to check whether a diagnostic is in the old or new SHA, we can't just return the new line number.