### PR TITLE
Feat: Check feature branch is up-to-date on remote

### DIFF
--- a/lua/gitlab/actions/create_mr.lua
+++ b/lua/gitlab/actions/create_mr.lua
@@ -43,16 +43,7 @@ end
 --- continue working on it.
 ---@param args? Mr
 M.start = function(args)
-  local current_branch, remote_up_to_date = git.current_branch_up_to_date_on_remote()
-  if not remote_up_to_date then
-    u.notify(
-      "You have unpushed changes. If your feature branch exists on remote, use\n"
-        .. "    git push\n"
-        .. "To push the current branch and set the remote as upstream, use\n"
-        .. "    git push --set-upstream origin "
-        .. current_branch,
-      vim.log.levels.WARN
-    )
+  if not git.current_branch_up_to_date_on_remote("ERROR") then
     return
   end
 

--- a/lua/gitlab/actions/create_mr.lua
+++ b/lua/gitlab/actions/create_mr.lua
@@ -43,6 +43,19 @@ end
 --- continue working on it.
 ---@param args? Mr
 M.start = function(args)
+  local current_branch, remote_up_to_date = git.current_branch_up_to_date_on_remote()
+  if not remote_up_to_date then
+    u.notify(
+      "You have unpushed changes. If your feature branch exists on remote, use\n"
+        .. "    git push\n"
+        .. "To push the current branch and set the remote as upstream, use\n"
+        .. "    git push --set-upstream origin "
+        .. current_branch,
+      vim.log.levels.WARN
+    )
+    return
+  end
+
   if M.started then
     vim.ui.select({ "Yes", "No" }, { prompt = "Continue your previous MR?" }, function(choice)
       if choice == "Yes" then

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -3,6 +3,7 @@
 -- send edits to the description back to Gitlab
 local Layout = require("nui.layout")
 local Popup = require("nui.popup")
+local git = require("gitlab.git")
 local job = require("gitlab.job")
 local common = require("gitlab.actions.common")
 local u = require("gitlab.utils")
@@ -70,6 +71,8 @@ M.summary = function()
 
     vim.api.nvim_set_current_buf(description_popup.bufnr)
   end)
+
+  git.current_branch_up_to_date_on_remote("WARN")
 end
 
 -- Builds a lua list of strings that contain metadata about the current MR. Only builds the

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -1,3 +1,5 @@
+local List = require("gitlab.utils.list")
+
 local M = {}
 
 M.has_clean_tree = function()
@@ -10,6 +12,43 @@ end
 
 M.switch_branch = function(branch)
   return vim.fn.trim(vim.fn.system({ "git", "checkout", "-q", branch }))
+end
+
+---Return the name of the current branch
+---@return string|nil
+M.get_current_branch = function()
+  local handle = io.popen("git branch --show-current 2>&1")
+  if handle then
+    return handle:read()
+  else
+    require("gitlab.utils").notify("Error running 'git branch' command.", vim.log.levels.ERROR)
+  end
+end
+
+---Return the list of names of all remote-tracking branches or an empty list.
+---@return table
+M.get_all_remote_branches = function()
+  local all_branches = {}
+  local handle = io.popen("git branch -r 2>&1")
+  if not handle then
+    require("gitlab.utils").notify("Error running 'git branch' command.", vim.log.levels.ERROR)
+    return all_branches
+  end
+
+  for line in handle:lines() do
+    table.insert(all_branches, line)
+  end
+  handle:close()
+
+  return List.new(all_branches)
+    :map(function(line)
+      -- Trim "origin/"
+      return line:match("origin/(%S+)")
+    end)
+    :filter(function(branch)
+      -- Don't include the HEAD pointer
+      return not branch:match("^HEAD$")
+    end)
 end
 
 return M

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -67,10 +67,9 @@ M.current_branch_up_to_date_on_remote = function(log_level)
   end
   handle:close()
 
-  local current_head_on_remote = List.new(remote_branches_with_current_head)
-    :filter(function(line)
-      return line == "  origin/" .. current_branch
-    end)
+  local current_head_on_remote = List.new(remote_branches_with_current_head):filter(function(line)
+    return line == "  origin/" .. current_branch
+  end)
   local remote_up_to_date = #current_head_on_remote == 1
 
   if not remote_up_to_date then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -86,6 +86,8 @@ M.open = function()
     discussions.close()
     require("gitlab").toggle_discussions() -- Fetches data and opens discussions
   end
+
+  git.current_branch_up_to_date_on_remote("WARN")
 end
 
 -- Closes the reviewer and cleans up


### PR DESCRIPTION
This PR add the feature that the up-to-date status of the remote feature branch is checked before creating a MR and when starting a review or opening the summary.
When the remote/origin feature branch does not contain the local HEAD (checked with `git branch -r --contains <feature-branch>`), a message is shown:
1. For `gitlab.create_mr()` this is an error and the MR creation is aborted.
2. For `gitlab.review()` and `gitlab.summary()` this is just a warning.