### PR TITLE
fix: draft note edits + reply keybinding

### DIFF
--- a/cmd/draft_notes.go
+++ b/cmd/draft_notes.go
@@ -22,7 +22,8 @@ type PostDraftNoteRequest struct {
 }
 
 type UpdateDraftNoteRequest struct {
-	Note string `json:"note"`
+	Note     string `json:"note"`
+	Position gitlab.PositionOptions
 }
 
 type DraftNotePublishRequest struct {
@@ -242,7 +243,8 @@ func (a *api) updateDraftNote(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opt := gitlab.UpdateDraftNoteOptions{
-		Note: &updateDraftNoteRequest.Note,
+		Note:     &updateDraftNoteRequest.Note,
+		Position: &updateDraftNoteRequest.Position,
 	}
 
 	draftNote, res, err := a.client.UpdateDraftNote(a.projectInfo.ProjectId, a.projectInfo.MergeId, id, &opt)

--- a/cmd/draft_notes_test.go
+++ b/cmd/draft_notes_test.go
@@ -106,7 +106,7 @@ func updateDraftNote(pid interface{}, mergeRequest int, note int, opt *gitlab.Up
 
 func TestEditDraftNote(t *testing.T) {
 	t.Run("Edits draft note", func(t *testing.T) {
-		request := makeRequest(t, http.MethodPatch, "/mr/draft_notes/3", UpdateDraftNoteRequest{Note: "Some new note"})
+		request := makeRequest(t, http.MethodPatch, "/mr/draft_notes/3", UpdateDraftNoteRequest{Note: "Some new note", Position: gitlab.PositionOptions{}})
 		server, _ := createRouterAndApi(fakeClient{updateDraftNote: updateDraftNote})
 		data := serveRequest(t, server, request, SuccessResponse{})
 		assert(t, data.Message, "Draft note updated")

--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -44,9 +44,9 @@ M.add_empty_titles = function()
   local draft_notes = require("gitlab.actions.draft_notes")
   local discussions = require("gitlab.actions.discussions")
   local linked, unlinked, drafts =
-      List.new(u.ensure_table(state.DISCUSSION_DATA and state.DISCUSSION_DATA.discussions)),
-      List.new(u.ensure_table(state.DISCUSSION_DATA and state.DISCUSSION_DATA.unlinked_discussions)),
-      List.new(u.ensure_table(state.DRAFT_NOTES))
+    List.new(u.ensure_table(state.DISCUSSION_DATA and state.DISCUSSION_DATA.discussions)),
+    List.new(u.ensure_table(state.DISCUSSION_DATA and state.DISCUSSION_DATA.unlinked_discussions)),
+    List.new(u.ensure_table(state.DRAFT_NOTES))
 
   local position_drafts = drafts:filter(function(note)
     return draft_notes.has_position(note)

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -215,6 +215,10 @@ end
 
 -- The reply popup will mount in a window when you trigger it (settings.discussion_tree.reply) when hovering over a node in the discussion tree.
 M.reply = function(tree)
+  if M.is_draft_note(tree) then
+    u.notify("Gitlab does not support replying to draft notes", vim.log.levels.WARN)
+    return
+  end
   local reply_popup = Popup(u.create_popup_state("Reply", state.settings.popup.reply))
   local node = tree:get_node()
   local discussion_node = common.get_root_node(tree, node)

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -46,32 +46,32 @@ M.add_draft_notes_to_table = function(unlinked)
   local draft_notes = List.new(state.DRAFT_NOTES)
 
   local draft_note_nodes = draft_notes
-      ---@param note DraftNote
-      :filter(function(note)
-        if unlinked then
-          return not M.has_position(note)
-        end
-        return M.has_position(note)
-      end)
-      ---@param note DraftNote
-      :map(function(note)
-        local _, root_text, root_text_nodes = discussion_tree.build_note(note)
-        return NuiTree.Node({
-          range = (type(note.position) == "table" and note.position.line_range or nil),
-          text = root_text,
-          type = "note",
-          is_root = true,
-          is_draft = true,
-          id = note.id,
-          root_note_id = note.id,
-          file_name = (type(note.position) == "table" and note.position.new_path or nil),
-          new_line = (type(note.position) == "table" and note.position.new_line or nil),
-          old_line = (type(note.position) == "table" and note.position.old_line or nil),
-          resolvable = false,
-          resolved = false,
-          url = state.INFO.web_url .. "#note_" .. note.id,
-        }, root_text_nodes)
-      end)
+    ---@param note DraftNote
+    :filter(function(note)
+      if unlinked then
+        return not M.has_position(note)
+      end
+      return M.has_position(note)
+    end)
+    ---@param note DraftNote
+    :map(function(note)
+      local _, root_text, root_text_nodes = discussion_tree.build_note(note)
+      return NuiTree.Node({
+        range = (type(note.position) == "table" and note.position.line_range or nil),
+        text = root_text,
+        type = "note",
+        is_root = true,
+        is_draft = true,
+        id = note.id,
+        root_note_id = note.id,
+        file_name = (type(note.position) == "table" and note.position.new_path or nil),
+        new_line = (type(note.position) == "table" and note.position.new_line or nil),
+        old_line = (type(note.position) == "table" and note.position.old_line or nil),
+        resolvable = false,
+        resolved = false,
+        url = state.INFO.web_url .. "#note_" .. note.id,
+      }, root_text_nodes)
+    end)
 
   return draft_note_nodes
 

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -47,20 +47,11 @@ local function create_diagnostic(range_info, d_or_n)
   return vim.tbl_deep_extend("force", diagnostic, range_info)
 end
 
----@param d_or_n Discussion|DraftNote
----@return integer
-M.get_line_number = function(d_or_n)
-  local first_note = indicators_common.get_first_note(d_or_n)
-  local linnr = (indicators_common.is_new_sha(d_or_n) and first_note.position.new_line or first_note.position.old_line) or
-      1
-  return linnr
-end
-
 ---Creates a single line diagnostic
 ---@param d_or_n Discussion|DraftNote
 ---@return Diagnostic
 local create_single_line_diagnostic = function(d_or_n)
-  local linnr = M.get_line_number(d_or_n)
+  local linnr = actions_common.get_line_number(d_or_n.id)
   return create_diagnostic({
     lnum = linnr - 1,
   }, d_or_n)

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -47,13 +47,20 @@ local function create_diagnostic(range_info, d_or_n)
   return vim.tbl_deep_extend("force", diagnostic, range_info)
 end
 
+---@param d_or_n Discussion|DraftNote
+---@return integer
+M.get_line_number = function(d_or_n)
+  local first_note = indicators_common.get_first_note(d_or_n)
+  local linnr = (indicators_common.is_new_sha(d_or_n) and first_note.position.new_line or first_note.position.old_line) or
+      1
+  return linnr
+end
+
 ---Creates a single line diagnostic
 ---@param d_or_n Discussion|DraftNote
 ---@return Diagnostic
 local create_single_line_diagnostic = function(d_or_n)
-  local first_note = indicators_common.get_first_note(d_or_n)
-  local linnr = (indicators_common.is_new_sha(d_or_n) and first_note.position.new_line or first_note.position.old_line)
-    or 1
+  local linnr = M.get_line_number(d_or_n)
   return create_diagnostic({
     lnum = linnr - 1,
   }, d_or_n)


### PR DESCRIPTION
Fixes issue with editing draft notes; jumping to correct position for draft notes; and replying (not supported) to draft notes.