### PR TITLE
Feat: Make toggle_draft_mode available outside discussion tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ vim.keymap.set("n", "glo", gitlab.open_in_browser)
 vim.keymap.set("n", "glM", gitlab.merge)
 vim.keymap.set("n", "glu", gitlab.copy_mr_url)
 vim.keymap.set("n", "glP", gitlab.publish_all_drafts)
+vim.keymap.set("n", "glD", gitlab.toggle_draft_mode)
 ```
 
 For more information about each of these commands, and about the APIs in general, run `:h gitlab.nvim.api`

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -321,13 +321,16 @@ Just like the summary, all the different kinds of comments are saved via the
 
 DRAFT NOTES                                       *gitlab.nvim.draft-comments*
 
-When you publish a "draft" of any of the above resources (configurable via the
-`state.settings.comments.default_to_draft` setting) the comment will be added
-to a review. You may publish all draft comments via the `gitlab.publish_all_drafts()`
-function, and you can publish an individual comment or note by pressing the
+When you publish a "draft" of any of the above resources, the comment will be
+added to a review. You can configure the default commenting mode (draft vs
+live) via the `state.settings.discussion_tree.draft_mode` setting, and you can
+toggle the setting with the `state.settings.discussion_tree.toggle_draft_mode`
+keybinding, or by calling the `gitlab.toggle_draft_mode()` function. You may
+publish all draft comments via the `gitlab.publish_all_drafts()` function, and
+you can publish an individual comment or note by pressing the
 `state.settings.discussion_tree.publish_draft` keybinding.
 
-Draft notes do not support editing, replying, or emojis.
+Draft notes do not support replying or emojis.
 
 TEMPORARY REGISTERS                               *gitlab.nvim.temp-registers*
 
@@ -765,6 +768,12 @@ comments visible.
 >lua
   require("gitlab").publish_all_drafts()
 <
+                                                                *gitlab.nvim.toggle_draft_mode*
+gitlab.toggle_draft_mode() ~
+
+Toggles between draft mode, where comments and notes are added to a review as
+drafts, and regular (or live) mode, where comments are posted immediately.
+
                                                                 *gitlab.nvim.add_assignee*
 gitlab.add_assignee() ~
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -560,6 +560,7 @@ in normal mode):
     vim.keymap.set("n", "glM", gitlab.merge)
     vim.keymap.set("n", "glu", gitlab.copy_mr_url)
     vim.keymap.set("n", "glP", gitlab.publish_all_drafts)
+    vim.keymap.set("n", "glD", gitlab.toggle_draft_mode)
 <
 
 TROUBLESHOOTING                                  *gitlab.nvim.troubleshooting*

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -529,8 +529,7 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
     end
   end, { buffer = bufnr, desc = "Delete comment" })
   vim.keymap.set("n", state.settings.discussion_tree.toggle_draft_mode, function()
-    state.settings.discussion_tree.draft_mode = not state.settings.discussion_tree.draft_mode
-    winbar.update_winbar()
+    M.toggle_draft_mode()
   end, { buffer = bufnr, desc = "Toggle between draft mode and live mode" })
   vim.keymap.set("n", state.settings.discussion_tree.toggle_resolved, function()
     if M.is_current_node_note(tree) and not M.is_draft_note(tree) then
@@ -661,6 +660,12 @@ M.toggle_tree_type = function()
     state.settings.discussion_tree.tree_type = "simple"
   end
   M.rebuild_discussion_tree()
+end
+
+---Toggle between draft mode (comments posted as drafts) and live mode (comments are posted immediately)
+M.toggle_draft_mode = function()
+  state.settings.discussion_tree.draft_mode = not state.settings.discussion_tree.draft_mode
+  winbar.update_winbar()
 end
 
 ---Indicates whether the node under the cursor is a draft note or not

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -74,7 +74,7 @@ return {
     draft_notes_dep,
     discussion_data,
   }, discussions.toggle),
-  toggle_draft_mode = async.sequence({ info }, discussions.toggle_draft_mode),
+  toggle_draft_mode = discussions.toggle_draft_mode,
   publish_all_drafts = draft_notes.publish_all_drafts,
   -- Other functions 🤷
   state = state,

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -74,9 +74,8 @@ return {
     draft_notes_dep,
     discussion_data,
   }, discussions.toggle),
-  toggle_resolved = async.sequence({ info }, discussions.toggle_discussion_resolved),
+  toggle_draft_mode = async.sequence({ info }, discussions.toggle_draft_mode),
   publish_all_drafts = draft_notes.publish_all_drafts,
-  reply = async.sequence({ info }, discussions.reply),
   -- Other functions 🤷
   state = state,
   data = data.data,


### PR DESCRIPTION
It's cool that the draft mode can be toggled without restarting Neovim. This PR makes this functionality available for mapping outside of the discussion tree.

Also, this PR some `gitlab.toggle_resolved`, and `gitlab.reply` as global actions, since they require a `tree` as a parameter, and they do not work when run like `require("gitlab").reply()`.