### PR TITLE
feat: support draft note replies

### DIFF
--- a/cmd/draft_notes.go
+++ b/cmd/draft_notes.go
@@ -17,7 +17,8 @@ as when they are creating a normal comment, but the Gitlab
 endpoints + resources we handle are different */
 
 type PostDraftNoteRequest struct {
-	Comment string `json:"comment"`
+	Comment      string `json:"comment"`
+	DiscussionId string `json:"discussion_id,omitempty"`
 	PositionData
 }
 
@@ -143,9 +144,11 @@ func (a *api) postDraftNote(w http.ResponseWriter, r *http.Request) {
 
 	opt := gitlab.CreateDraftNoteOptions{
 		Note: &postDraftNoteRequest.Comment,
-		// TODO: Support posting replies as drafts and rendering draft replies in the discussion tree
-		// instead of the notes tree
-		// InReplyToDiscussionID *string          `url:"in_reply_to_discussion_id,omitempty" json:"in_reply_to_discussion_id,omitempty"`
+	}
+
+	// Draft notes can be posted in "response" to existing discussions
+	if postDraftNoteRequest.DiscussionId != "" {
+		opt.InReplyToDiscussionID = gitlab.Ptr(postDraftNoteRequest.DiscussionId)
 	}
 
 	if postDraftNoteRequest.FileName != "" {

--- a/cmd/reply.go
+++ b/cmd/reply.go
@@ -12,6 +12,7 @@ import (
 type ReplyRequest struct {
 	DiscussionId string `json:"discussion_id"`
 	Reply        string `json:"reply"`
+	IsDraft      bool   `json:"is_draft"`
 }
 
 type ReplyResponse struct {

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -52,7 +52,7 @@ local confirm_create_comment = function(text, visual_range, unlinked, discussion
   end
 
   -- Creating a note (unlinked comment)
-  if unlinked then
+  if unlinked and discussion_id == nil then
     local body = { comment = text }
     local endpoint = is_draft and "/mr/draft_notes/" or "/mr/comment"
     job.run_job(endpoint, "POST", body, function()

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -258,10 +258,10 @@ M.delete_comment = function(tree, unlinked)
       end
 
       ---@type integer
-      local note_id = note_node.is_root and root_node.root_note_id or note_node.id
-      if root_node.is_draft then
-        draft_notes.confirm_delete_draft_note(note_id, unlinked)
+      if M.is_draft_note(tree) then
+        draft_notes.confirm_delete_draft_note(note_node.id, unlinked)
       else
+        local note_id = note_node.is_root and root_node.root_note_id or note_node.id
         local comment = require("gitlab.actions.comment")
         comment.confirm_delete_comment(note_id, root_node.id, unlinked)
       end
@@ -296,10 +296,11 @@ M.edit_comment = function(tree, unlinked)
   vim.api.nvim_buf_set_lines(currentBuffer, 0, -1, false, lines)
 
   -- Draft notes module handles edits for draft notes
-  if root_node.is_draft then
+  if M.is_draft_note(tree) then
+    vim.print(note_node)
     state.set_popup_keymaps(
       edit_popup,
-      draft_notes.confirm_edit_draft_note(root_node.id, unlinked),
+      draft_notes.confirm_edit_draft_note(note_node.id, unlinked),
       nil,
       miscellaneous.editable_popup_opts
     )
@@ -649,6 +650,10 @@ end
 ---@return boolean
 M.is_draft_note = function(tree)
   local current_node = tree:get_node()
+  local note_node = common.get_note_node(tree, current_node)
+  if note_node and note_node.is_draft then
+    return true
+  end
   local root_node = common.get_root_node(tree, current_node)
   return root_node ~= nil and root_node.is_draft
 end

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -427,13 +427,7 @@ M.rebuild_discussion_tree = function()
   local draft_comment_nodes = draft_notes.add_draft_notes_to_table(false)
 
   -- Combine inline draft notes with regular comments
-  local all_nodes = {}
-  for _, draft_node in ipairs(draft_comment_nodes) do
-    table.insert(all_nodes, draft_node)
-  end
-  for _, node in ipairs(existing_comment_nodes) do
-    table.insert(all_nodes, node)
-  end
+  local all_nodes = u.join(draft_comment_nodes, existing_comment_nodes)
 
   local discussion_tree = NuiTree({
     nodes = all_nodes,
@@ -467,13 +461,7 @@ M.rebuild_unlinked_discussion_tree = function()
   local draft_comment_nodes = draft_notes.add_draft_notes_to_table(true)
 
   -- Combine draft notes with regular notes
-  local all_nodes = {}
-  for _, draft_node in ipairs(draft_comment_nodes) do
-    table.insert(all_nodes, draft_node)
-  end
-  for _, node in ipairs(existing_note_nodes) do
-    table.insert(all_nodes, node)
-  end
+  local all_nodes = u.join(draft_comment_nodes, existing_note_nodes)
 
   local unlinked_discussion_tree = NuiTree({
     nodes = all_nodes,

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -56,6 +56,9 @@ M.add_draft_notes_to_table = function(unlinked)
       end
       return M.has_position(note)
     end)
+    :filter(function(note)
+      return note.discussion_id == "" -- Do not include draft replies
+    end)
     ---@param note DraftNote
     :map(function(note)
       local _, root_text, root_text_nodes = discussion_tree.build_note(note)

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -14,7 +14,7 @@ local M = {}
 
 ---Re-fetches all draft notes (and non-draft notes) and re-renders the relevant views
 ---@param unlinked boolean
----@param all boolean
+---@param all boolean|nil
 M.rebuild_view = function(unlinked, all)
   M.load_draft_notes(function()
     local discussions = require("gitlab.actions.discussions")

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -80,12 +80,6 @@ M.add_draft_notes_to_table = function(unlinked)
     end)
 
   return draft_note_nodes
-
-  -- TODO: Combine draft_notes and normal discussion nodes in the complex discussion
-  -- tree. The code for that feature is a clusterfuck so this is difficult
-  -- if state.settings.discussion_tree.tree_type == "simple" then
-  --   return draft_note_nodes
-  -- end
 end
 
 ---Will actually send the edits to Gitlab and refresh the draft_notes tree

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -126,12 +126,6 @@ M.has_position = function(note)
   return note.position.new_path ~= nil or note.position.old_path ~= nil
 end
 
-M.build_reply_draft_note = function(note)
-  local discussions = require("gitlab.actions.discussions")
-  local text, text_nodes = discussions.build_note_body(note)
-  return NuiTree.Node({})
-end
-
 ---Builds a note for the discussion tree for draft notes that are roots
 ---of their own discussions, e.g. not replies
 ---@param note DraftNote

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -42,12 +42,34 @@ M.has_position = function(note)
   return note.position.new_path ~= nil or note.position.old_path ~= nil
 end
 
+---Builds a note for the discussion tree for draft notes that are roots
+---of their own discussions, e.g. not replies
+---@param note DraftNote
+---@return NuiTree.Node
+M.build_root_draft_note = function(note)
+  local _, root_text, root_text_nodes = discussion_tree.build_note(note)
+  return NuiTree.Node({
+    range = (type(note.position) == "table" and note.position.line_range or nil),
+    text = root_text,
+    type = "note",
+    is_root = true,
+    is_draft = true,
+    id = note.id,
+    root_note_id = note.id,
+    file_name = (type(note.position) == "table" and note.position.new_path or nil),
+    new_line = (type(note.position) == "table" and note.position.new_line or nil),
+    old_line = (type(note.position) == "table" and note.position.old_line or nil),
+    resolvable = false,
+    resolved = false,
+    url = state.INFO.web_url .. "#note_" .. note.id,
+  }, root_text_nodes)
+end
+
 ---Returns a list of nodes to add to the discussion tree. Can filter and return only unlinked (note) nodes.
 ---@param unlinked boolean
 ---@return NuiTree.Node[]
 M.add_draft_notes_to_table = function(unlinked)
   local draft_notes = List.new(state.DRAFT_NOTES)
-
   local draft_note_nodes = draft_notes
     ---@param note DraftNote
     :filter(function(note)
@@ -59,25 +81,7 @@ M.add_draft_notes_to_table = function(unlinked)
     :filter(function(note)
       return note.discussion_id == "" -- Do not include draft replies
     end)
-    ---@param note DraftNote
-    :map(function(note)
-      local _, root_text, root_text_nodes = discussion_tree.build_note(note)
-      return NuiTree.Node({
-        range = (type(note.position) == "table" and note.position.line_range or nil),
-        text = root_text,
-        type = "note",
-        is_root = true,
-        is_draft = true,
-        id = note.id,
-        root_note_id = note.id,
-        file_name = (type(note.position) == "table" and note.position.new_path or nil),
-        new_line = (type(note.position) == "table" and note.position.new_line or nil),
-        old_line = (type(note.position) == "table" and note.position.old_line or nil),
-        resolvable = false,
-        resolved = false,
-        url = state.INFO.web_url .. "#note_" .. note.id,
-      }, root_text_nodes)
-    end)
+    :map(M.build_root_draft_note)
 
   return draft_note_nodes
 end


### PR DESCRIPTION
This MR moves draft note _replies_ into the correct tree.

Previously, we did not distinguish between top-level draft notes and "draft replies" which are sent in response to an existing discussion. The Gitlab API requires you to specify the ID of the discussion you are replying to.

This MR updates the discussion tree and unlinked discussion tree to properly nest the draft replies under their respective discussions, and updates the draft notes modal to allow for posting live and draft replies.