### PR TITLE
Fix: Use backticks in code suggestions

### DIFF
--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -284,8 +284,8 @@ local build_suggestion = function()
   local backticks = "```"
   local selected_lines = u.get_lines(M.start_line, M.end_line)
 
-  for line in ipairs(selected_lines) do
-    if string.match(line, "^```$") then
+  for _, line in ipairs(selected_lines) do
+    if string.match(line, "^```%S*$") then
       backticks = "````"
       break
     end


### PR DESCRIPTION
This PR fixes how backticks in code suggestions are identified:
1. The original iteration compared to the indeces, not to the values of the table of all lines.
2. The original regex didn't allow backtics with a filetype specification, e.g., "```bash".