### PR TITLE
Fix: List remote branches for merge targets

### DIFF
--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -18,7 +18,7 @@ end
 ---Returns all branches for the current repository
 ---@return string|nil, string|nil
 M.branches = function()
-  return run_system({ "git", "branch" })
+  return run_system({ "git", "branch", "-r" })
 end
 
 ---Checks whether the tree has any changes that haven't been pushed to the remote


### PR DESCRIPTION
This PR restores the `-r` flag for `git branch` that was removed by a recent refactor in order to list the `remote` branches for MR targets.