### PR TITLE
Fix: Copy node url to clipboard

### DIFF
--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -113,7 +113,7 @@ end
 ---@param tree NuiTree
 M.copy_node_url = function(tree)
   local url = M.get_url(tree)
-  if url == nil then
+  if url ~= nil then
     vim.fn.setreg("+", url)
     u.notify("Copied '" .. url .. "' to clipboard", vim.log.levels.INFO)
   end


### PR DESCRIPTION
This PR fixes a small mistake that caused the node url not to be copied.