### PR TITLE
Fix diagnostic position when sha changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For more settings, please see `:h gitlab.nvim.connecting-to-gitlab`
 
 The plugin expects you to call `setup()` and pass in a table of options. All of these values are optional, and if you call this function with no values the defaults will be used.
 
-For a list of all these settings please run `:h gitlab.nvim.configuring-the-plugin` which will show you the help stored in `doc/gitlab.nvim.txt`
+For a list of all these settings please run `:h gitlab.nvim.configuring-the-plugin` which will show you the help stored in [doc/gitlab.nvim.txt](doc/gitlab.nvim.txt).
 
 ## Keybindings
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For more settings, please see `:h gitlab.nvim.connecting-to-gitlab`
 
 The plugin expects you to call `setup()` and pass in a table of options. All of these values are optional, and if you call this function with no values the defaults will be used.
 
-For a list of all these settings please run `:h gitlab.nvim` which is stored in `doc/gitlab.nvim.txt`
+For a list of all these settings please run `:h gitlab.nvim.configuring-the-plugin` which will show you the help stored in `doc/gitlab.nvim.txt`
 
 ## Keybindings
 

--- a/README.md
+++ b/README.md
@@ -155,3 +155,7 @@ vim.keymap.set("n", "glD", gitlab.toggle_draft_mode)
 ```
 
 For more information about each of these commands, and about the APIs in general, run `:h gitlab.nvim.api`
+
+## Contributing
+
+Contributions to the plugin are welcome. Please read [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) before you start working on a pull request.

--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -183,8 +183,8 @@ local function get_new_line(node)
     return node.new_line
   end
 
-  local _, start_new_line = common_indicators.parse_line_code(range.start.line_code)
-  return start_new_line
+  local _, new_start_line = indicators_common.parse_line_code(range.start.line_code)
+  return new_start_line
 end
 
 ---Takes a node and returns the line where the note is positioned in the old SHA. If
@@ -198,8 +198,8 @@ local function get_old_line(node)
     return node.old_line
   end
 
-  local start_old_line, _ = common_indicators.parse_line_code(range.start.line_code)
-  return start_old_line
+  local old_start_line, _ = indicators_common.parse_line_code(range.start.line_code)
+  return old_start_line
 end
 
 ---@param id string|integer
@@ -225,8 +225,8 @@ end
 ---@return integer|nil
 M.get_line_number_from_node = function(root_node)
   if root_node.range then
-    local start_old_line, start_new_line = common_indicators.parse_line_code(root_node.range.start.line_code)
-    return root_node.old_line and start_old_line or start_new_line
+    local old_start_line, new_start_line = common_indicators.parse_line_code(root_node.range.start.line_code)
+    return root_node.old_line and old_start_line or new_start_line
   else
     return M.get_line_number(root_node.id)
   end

--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -226,7 +226,8 @@ end
 M.get_line_number_from_node = function(root_node)
   if root_node.range then
     local old_start_line, new_start_line = common_indicators.parse_line_code(root_node.range.start.line_code)
-    return root_node.old_line and old_start_line or new_start_line
+    local old_end_line, new_end_line = indicators_common.parse_line_code(root_node.range["end"].line_code)
+    return root_node.old_line and (old_start_line + root_node.old_line - old_end_line) or (new_start_line + root_node.new_line - new_end_line)
   else
     return M.get_line_number(root_node.id)
   end

--- a/lua/gitlab/actions/discussions/annotations.lua
+++ b/lua/gitlab/actions/discussions/annotations.lua
@@ -133,3 +133,17 @@
 ---@field commit_id string  -- This will always be ""
 ---@field line_code string
 ---@field position NotePosition
+
+---@class RootNode: NuiTree.Node
+---@field range table
+---@field old_line integer|nil
+---@field new_line integer|nil
+---@field id string
+---@field text string
+---@field type "note"
+---@field is_root boolean
+---@field root_note_id string
+---@field file_name string
+---@field resolvable boolean
+---@field resolved boolean
+---@field url string

--- a/lua/gitlab/hunks.lua
+++ b/lua/gitlab/hunks.lua
@@ -191,7 +191,7 @@ local function get_modification_type_from_new_sha(new_line, hunks, all_diff_outp
     return nil
   end
   return List.new(hunks):find(function(hunk)
-    local new_line_end = hunk.new_line + hunk.new_range
+    local new_line_end = hunk.new_line + hunk.new_range - (hunk.new_range > 0 and 1 or 0)
     local in_new_range = new_line >= hunk.new_line and new_line <= new_line_end
     local is_range_zero = hunk.new_range == 0 and hunk.old_range == 0
     return in_new_range and (is_range_zero or line_was_added(new_line, hunk, all_diff_output))
@@ -209,10 +209,10 @@ local function get_modification_type_from_old_sha(old_line, new_line, hunks, all
   end
 
   return List.new(hunks):find(function(hunk)
-    local old_line_end = hunk.old_line + hunk.old_range
-    local new_line_end = hunk.new_line + hunk.new_range
+    local old_line_end = hunk.old_line + hunk.old_range - (hunk.old_range > 0 and 1 or 0)
+    local new_line_end = hunk.new_line + hunk.new_range - (hunk.new_range > 0 and 1 or 0)
     local in_old_range = old_line >= hunk.old_line and old_line <= old_line_end
-    local in_new_range = old_line >= hunk.new_line and new_line <= new_line_end
+    local in_new_range = new_line >= hunk.new_line and new_line <= new_line_end
     return (in_old_range or in_new_range) and line_was_removed(old_line, hunk, all_diff_output)
   end) and "deleted" or "unmodified"
 end

--- a/lua/gitlab/indicators/common.lua
+++ b/lua/gitlab/indicators/common.lua
@@ -68,7 +68,11 @@ end
 ---@return boolean
 M.is_old_sha = function(d_or_n)
   local first_note = M.get_first_note(d_or_n)
-  return first_note.position.old_line ~= nil
+  local old_start_line
+  if first_note.position.line_range ~= nil then
+    old_start_line, _ = M.parse_line_code(first_note.position.line_range.start.line_code)
+  end
+  return first_note.position.old_line ~= nil and old_start_line ~= 0
 end
 
 ---@param discussion Discussion|DraftNote

--- a/lua/gitlab/indicators/common.lua
+++ b/lua/gitlab/indicators/common.lua
@@ -67,12 +67,9 @@ end
 ---@param d_or_n Discussion|DraftNote
 ---@return boolean
 M.is_old_sha = function(d_or_n)
-  local first_note = M.get_first_note(d_or_n)
-  local old_start_line
-  if first_note.position.line_range ~= nil then
-    old_start_line, _ = M.parse_line_code(first_note.position.line_range.start.line_code)
-  end
-  return first_note.position.old_line ~= nil and old_start_line ~= 0
+  local position = M.get_first_note(d_or_n).position
+  local old_start_line = position.line_range ~= nil and M.parse_line_code(position.line_range.start.line_code) or nil
+  return position.old_line ~= nil and old_start_line ~= 0
 end
 
 ---@param discussion Discussion|DraftNote

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -72,22 +72,17 @@ local create_multiline_diagnostic = function(d_or_n)
     error("Parsing multi-line comment but note does not contain line range")
   end
 
-  local old_start_line, new_start_line = indicators_common.parse_line_code(line_range.start.line_code)
-  local old_end_line, new_end_line = indicators_common.parse_line_code(line_range["end"].line_code)
+  local start_line, end_line = actions_common.get_line_numbers_for_range(
+    first_note.position.old_line,
+    first_note.position.new_line,
+    line_range.start.line_code,
+    line_range["end"].line_code
+  )
 
-  if indicators_common.is_new_sha(d_or_n) then
-    local range = new_end_line - new_start_line
-    return create_diagnostic({
-      lnum = first_note.position.new_line - 1 - range,
-      end_lnum = first_note.position.new_line - 1,
-    }, d_or_n)
-  else
-    local range = old_end_line - old_start_line
-    return create_diagnostic({
-      lnum = first_note.position.old_line - 1 - range,
-      end_lnum = first_note.position.old_line - 1,
-    }, d_or_n)
-  end
+  return create_diagnostic({
+    lnum = start_line - 1,
+    end_lnum = end_line - 1,
+  }, d_or_n)
 end
 
 ---Set diagnostics in currently new SHA.

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -72,16 +72,16 @@ local create_multiline_diagnostic = function(d_or_n)
     error("Parsing multi-line comment but note does not contain line range")
   end
 
-  local start_old_line, start_new_line = indicators_common.parse_line_code(line_range.start.line_code)
+  local old_start_line, new_start_line = indicators_common.parse_line_code(line_range.start.line_code)
 
   if indicators_common.is_new_sha(d_or_n) then
     return create_diagnostic({
-      lnum = start_new_line - 1,
+      lnum = new_start_line - 1,
       end_lnum = first_note.position.new_line - 1,
     }, d_or_n)
   else
     return create_diagnostic({
-      lnum = start_old_line - 1,
+      lnum = old_start_line - 1,
       end_lnum = first_note.position.old_line - 1,
     }, d_or_n)
   end

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -73,15 +73,18 @@ local create_multiline_diagnostic = function(d_or_n)
   end
 
   local old_start_line, new_start_line = indicators_common.parse_line_code(line_range.start.line_code)
+  local old_end_line, new_end_line = indicators_common.parse_line_code(line_range["end"].line_code)
 
   if indicators_common.is_new_sha(d_or_n) then
+    local range = new_end_line - new_start_line
     return create_diagnostic({
-      lnum = new_start_line - 1,
+      lnum = first_note.position.new_line - 1 - range,
       end_lnum = first_note.position.new_line - 1,
     }, d_or_n)
   else
+    local range = old_end_line - old_start_line
     return create_diagnostic({
-      lnum = old_start_line - 1,
+      lnum = first_note.position.old_line - 1 - range,
       end_lnum = first_note.position.old_line - 1,
     }, d_or_n)
   end

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -72,7 +72,7 @@ local create_multiline_diagnostic = function(d_or_n)
     error("Parsing multi-line comment but note does not contain line range")
   end
 
-  local start_line, end_line = actions_common.get_line_numbers_for_range(
+  local start_line, end_line, _ = actions_common.get_line_numbers_for_range(
     first_note.position.old_line,
     first_note.position.new_line,
     line_range.start.line_code,

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -522,6 +522,7 @@ M.create_box_popup_state = function(title, enter)
         top = title,
       },
     },
+    opacity = settings.opacity,
   }
 end
 


### PR DESCRIPTION
This PR is an attempt to improve diagnostic placement and `jump_to_reviewer` behaviour reported in #158.

It introduces the following changes:
1. The position of a diagnostic and for `jump_to_reviewer` is calculated with a common function, reducing the potential for incorrect jumps
2. The position for ranged diagnostics is based on the `first_note.position.new_line` or `first_note.position.old_line`, rather than the `line_code` - in my experience, this tends to be the most accurate source of information about where to place diagnostics, see example below. The information in the `line_code`s is used to calculate the length of the diagnostic range, though.
3. Old SHA detection is improved. Relying on the `old_line` only is not always reliable, I've come across notes that had a non-nil `old_line`, but still should be placed in the NEW buffer, since the line code for `range.start` looked something like this: `"a34a68046a50849178410fce4af6182a98526bfc_0_94"`, -> the start of the diagnostic was not set (was `0`) and the code that calculated the diagnostic position `lnum = new_start_line - 1` produced a negative value, which caused an error. 

I've been using this branch for some time and it looks like it improves the placement of many diagnostics, but it still does not solve all the problems. E.g., diagnostics are still misplaced for code that has been moved to a different file or for files that have been heavily modified. The good thing is, that this PR does not seem to produce worse results than the previous solution.

For the cases when diagnostics are still misplaced, I'd suggest to implement a feature that would open a new `DiffviewFileHistory` and select the revision on which the original note was made. Then the user will be free to navigate to newer versions of the file and easily see what changed so that the note placement is out of date. I'm going to open a new feature request for this.

## Example of diagnostics positions
In this example from a discussions tree node, the correct position is the top `new_line`, all the information in `range` (the `["end"].new_line` and both line numbers in `["end"].line_code` are outdated:  
```lua
  new_line = 93,
  range = {
    ["end"] = {
      line_code = "a34a68046a50849178410fce4af6182a98526bfc_96_94",
      new_line = 94,
      old_line = 0,
      type = "new"
    },
  },
```
![image](https://github.com/harrisoncramer/gitlab.nvim/assets/17056143/bd434b42-227b-4b9d-b9fd-8917e41f25c1)
