### PR TITLE
Fix: Ranged comment signs not showing

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ require("gitlab").setup({
     skip_resolved_discussion = false, -- Show diagnostics for resolved discussions
     severity = vim.diagnostic.severity.INFO, -- ERROR, WARN, INFO, or HINT
     virtual_text = false, -- Whether to show the comment text inline as floating virtual text
+    use_diagnostic_signs = true, -- Show diagnostic sign (depending on the `severity` setting, e.g., I for INFO) along with the comment icon
     priority = 100, -- Higher will override LSP warnings, etc
     icons = {
       comment = "→|",

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -420,14 +420,19 @@ have been added to a review. These are the default settings:
     },
   },
 
-When the cursor is on diagnostic line you can view discussion thread by using `vim.diagnostic.show()`
+When the cursor is on a diagnostic line you can view the discussion thread by
+using `vim.diagnostic.show()`.
 
-You can also jump to discussion tree for the given comment:
+You can also jump to the discussion tree for the given comment:
 >lua
     require("gitlab").move_to_discussion_tree_from_diagnostic()
 
+Since nvim 0.10 you can use these two function anywhere in the diagnostic
+range. In previous versions, you have to move the cursor to the first line of
+the diagnostic.
+
 You may skip resolved discussions by toggling `discussion_signs.skip_resolved_discussion`
-in your setup function to true. By default, discussions from this plugin
+in your setup function to `true`. By default, discussions from this plugin
 are shown at the INFO severity level (see :h vim.diagnostic.severity).
 
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -240,6 +240,7 @@ you call this function with no values the defaults will be used:
         skip_resolved_discussion = false, -- Show diagnostics for resolved discussions
         severity = vim.diagnostic.severity.INFO, -- ERROR, WARN, INFO, or HINT
         virtual_text = false, -- Whether to show the comment text inline as floating virtual text
+        use_diagnostic_signs = true, -- Show diagnostic sign (depending on the `severity` setting, e.g., I for INFO) along with the comment icon
         priority = 100, -- Higher will override LSP warnings, etc
         icons = {
           comment = "→|",
@@ -413,6 +414,7 @@ have been added to a review. These are the default settings:
     skip_resolved_discussion = false, -- Show diagnostics for resolved discussions
     severity = vim.diagnostic.severity.INFO, -- ERROR, WARN, INFO, or HINT
     virtual_text = false, -- Whether to show the comment text inline as floating virtual text
+    use_diagnostic_signs = true, -- Show diagnostic sign (depending on the `severity` setting, e.g., I for INFO) along with the comment icon
     priority = 100, -- Higher will override LSP warnings, etc
     icons = {
       comment = "→|",

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -160,6 +160,9 @@ you call this function with no values the defaults will be used:
           imply_local = false, -- If true, will attempt to use --imply_local option when calling |:DiffviewOpen|
         },
       },
+      connection_settings = {
+        insecure = false, -- Like curl's --insecure option, ignore bad x509 certificates on connection
+      },
       help = "g?", -- Opens a help popup for local keymaps when a relevant view is focused (popup, discussion panel, etc)
       popup = { -- The popup for comment creation, editing, and replying
         keymaps = {
@@ -192,12 +195,14 @@ you call this function with no values the defaults will be used:
         refresh_data = "a", -- Refreshes the data in the view by hitting Gitlab's APIs again
         reply = "r", -- Reply to comment
         toggle_node = "t", -- Opens or closes the discussion
+        add_emoji = "Ea" -- Add an emoji to the note/comment
+        add_emoji = "Ed" -- Remove an emoji from a note/comment
         toggle_all_discussions = "T", -- Open or close separately both resolved and unresolved discussions
         toggle_resolved_discussions = "R", -- Open or close all resolved discussions
         toggle_unresolved_discussions = "U", -- Open or close all unresolved discussions
         keep_current_open = false, -- If true, current discussion stays open even if it should otherwise be closed when toggling
-        toggle_resolved = "p" -- Toggles the resolved status of the whole discussion
         publish_draft = "P", -- Publishes the currently focused note/comment
+        toggle_resolved = "p" -- Toggles the resolved status of the whole discussion
         position = "left", -- "top", "right", "bottom" or "left"
         open_in_browser = "b" -- Jump to the URL of the current note/discussion
         copy_node_url = "u", -- Copy the URL of the current node to clipboard
@@ -208,7 +213,7 @@ you call this function with no values the defaults will be used:
         tree_type = "simple", -- Type of discussion tree - "simple" means just list of discussions, "by_file_name" means file tree with discussions under file
         toggle_tree_type = "i", -- Toggle type of discussion tree - "simple", or "by_file_name"
         draft_mode = false, -- Whether comments are posted as drafts as part of a review
-        toggle_draft_mode = "D" -- Toggle between draft mode and regular mode, where comments are posted immediately
+        toggle_draft_mode = "D" -- Toggle between draft mode (comments posted as drafts) and live mode (comments are posted immediately)
         winbar = nil -- Custom function to return winbar title, should return a string. Provided with WinbarTable (defined in annotations.lua)
                      -- If using lualine, please add "gitlab" to disabled file types, otherwise you will not see the winbar.
       },
@@ -218,7 +223,7 @@ you call this function with no values the defaults will be used:
       info = { -- Show additional fields in the summary view
         enabled = true,
         horizontal = false, -- Display metadata to the left of the summary rather than underneath
-        fields = {  -- The fields listed here will be displayed, in whatever order you choose
+        fields = { -- The fields listed here will be displayed, in whatever order you choose
           "author",
           "created_at",
           "updated_at",
@@ -276,7 +281,7 @@ you call this function with no values the defaults will be used:
           directory = "Directory",
           directory_icon = "DiffviewFolderSign",
           file_name = "Normal",
-          }
+        }
       }
     })
 <

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -15,7 +15,7 @@ M.clear_diagnostics = function()
 end
 
 -- Display options for the diagnostic
-local create_display_opts = function ()
+local create_display_opts = function()
   return {
     virtual_text = state.settings.discussion_signs.virtual_text,
     severity_sort = true,

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -15,11 +15,14 @@ M.clear_diagnostics = function()
 end
 
 -- Display options for the diagnostic
-local display_opts = {
-  virtual_text = state.settings.discussion_signs.virtual_text,
-  severity_sort = true,
-  underline = false,
-}
+local create_display_opts = function ()
+  return {
+    virtual_text = state.settings.discussion_signs.virtual_text,
+    severity_sort = true,
+    underline = false,
+    signs = state.settings.discussion_signs.use_diagnostic_signs,
+  }
+end
 
 ---Takes some range information and data about a discussion
 ---and creates a diagnostic to be placed in the reviewer
@@ -121,10 +124,10 @@ M.refresh_diagnostics = function()
     end
 
     local new_diagnostics = M.parse_new_diagnostics(filtered_discussions)
-    set_diagnostics_in_new_sha(diagnostics_namespace, new_diagnostics, display_opts)
+    set_diagnostics_in_new_sha(diagnostics_namespace, new_diagnostics, create_display_opts())
 
     local old_diagnostics = M.parse_old_diagnostics(filtered_discussions)
-    set_diagnostics_in_old_sha(diagnostics_namespace, old_diagnostics, display_opts)
+    set_diagnostics_in_old_sha(diagnostics_namespace, old_diagnostics, create_display_opts())
   end)
 
   if not ok then

--- a/lua/gitlab/indicators/signs.lua
+++ b/lua/gitlab/indicators/signs.lua
@@ -2,7 +2,6 @@ local u = require("gitlab.utils")
 local state = require("gitlab.state")
 local List = require("gitlab.utils.list")
 local discussion_sign_name = require("gitlab.indicators.diagnostics").discussion_sign_name
-local namespace = require("gitlab.indicators.diagnostics").diagnostics_namespace
 
 local M = {}
 M.clear_signs = function()
@@ -32,9 +31,8 @@ M.set_signs = function(diagnostics, bufnr)
   for _, diagnostic in ipairs(diagnostics) do
     ---@type SignTable[]
     local existing_signs =
-      vim.fn.sign_getplaced(vim.api.nvim_get_current_buf(), { group = "gitlab_discussion" })[1].signs
+      vim.fn.sign_getplaced(vim.api.nvim_get_current_buf(), { group = discussion_sign_name })[1].signs
 
-    local sign_id = string.format("%s__%d", namespace, diagnostic.lnum)
     if diagnostic.end_lnum then
       local linenr = diagnostic.lnum + 1
       while linenr <= diagnostic.end_lnum do
@@ -44,7 +42,7 @@ M.set_signs = function(diagnostics, bufnr)
         end)
         if conflicting_comment_sign == nil then
           vim.fn.sign_place(
-            sign_id,
+            linenr,
             discussion_sign_name,
             "DiagnosticSign" .. M.severity .. gitlab_range,
             bufnr,
@@ -55,7 +53,7 @@ M.set_signs = function(diagnostics, bufnr)
     end
 
     vim.fn.sign_place(
-      sign_id,
+      diagnostic.lnum + 1,
       discussion_sign_name,
       "DiagnosticSign" .. M.severity .. gitlab_comment,
       bufnr,

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -149,6 +149,7 @@ M.settings = {
     skip_resolved_discussion = false,
     severity = vim.diagnostic.severity.INFO,
     virtual_text = false,
+    use_diagnostic_signs = true,
     icons = {
       comment = "→|",
       range = " |",


### PR DESCRIPTION
Addresses #302.

This PR also makes it possible to hide the diagnostic sign (e.g., `I` if the diagnostic level is "INFO") - this makes the diagnostic range icons better aligned. The default behaviour of the plugin does not change, i.e., the diagnostic signs are shown.

I've noticed one small bug that existed already with nvim 0.9, if some signs overlap, the `GitlabComment` icons are hidden by the `GitlabRange` icons the first time the signs are placed. This is because for some reason, this line in `lua/gitlab/indicators/signs.lua:33` does not return any already placed signs:
```lua
    local existing_signs =
      vim.fn.sign_getplaced(vim.api.nvim_get_current_buf(), { group = discussion_sign_name })[1].signs
```
On subsequent runs (e.g., when jumping to a diagnostic or when switching files in the review), the overlapping signs are placed correctly and the `GitlabComment` sign takes precedence. If I found the reason for this behaviour I would like to fix it in this PR, but I haven't been successful so far. Maybe it has to do with calling a `vim` function inside a `lua` script.

Regarding the small modifications of the documentation, there are still some inconsistencies between the default setup settings and the ones described in the README and docs (e.g., `skip_old_revision_discussion`), but right now I don't have the time to fix those. Have you considered keeping the settings in let's say just two places? The README could maybe only contain a link to the docs. It would be easier to maintain consistency.