### PR TITLE
Fix: Failure when unloading buffer

### DIFF
--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -63,10 +63,20 @@ M.summary = function()
       description_popup,
       M.edit_summary,
       miscellaneous.attach_file,
-      { cb = exit, action_before_close = true, save_to_temp_register = true }
+      { cb = exit, action_before_close = true, action_before_exit = true, save_to_temp_register = true }
     )
-    state.set_popup_keymaps(title_popup, M.edit_summary, nil, { cb = exit, action_before_close = true })
-    state.set_popup_keymaps(info_popup, M.edit_summary, nil, { cb = exit, action_before_close = true })
+    state.set_popup_keymaps(
+      title_popup,
+      M.edit_summary,
+      nil,
+      { cb = exit, action_before_close = true, action_before_exit = true }
+    )
+    state.set_popup_keymaps(
+      info_popup,
+      M.edit_summary,
+      nil,
+      { cb = exit, action_before_close = true, action_before_exit = true }
+    )
     miscellaneous.set_cycle_popups_keymaps(popups)
 
     vim.api.nvim_set_current_buf(description_popup.bufnr)
@@ -151,8 +161,6 @@ M.edit_summary = function()
     u.notify(data.message, vim.log.levels.INFO)
     state.INFO.description = data.mr.description
     state.INFO.title = data.mr.title
-    M.layout:unmount()
-    M.layout_visible = false
   end)
 end
 

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -295,9 +295,9 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
       local text = u.get_buffer_text(popup.bufnr)
       if opts.action_before_close then
         action(text, popup.bufnr)
-        vim.api.nvim_buf_delete(popup.bufnr, {})
+        exit(popup, opts)
       else
-        vim.api.nvim_buf_delete(popup.bufnr, {})
+        exit(popup, opts)
         action(text, popup.bufnr)
       end
     end, { buffer = popup.bufnr, desc = "Perform action" })
@@ -312,18 +312,26 @@ M.set_popup_keymaps = function(popup, action, linewise_action, opts)
     end, { buffer = popup.bufnr, desc = "Perform linewise action" })
   end
 
-  vim.api.nvim_create_autocmd("BufWinLeave", {
-    buffer = popup.bufnr,
-    callback = function()
-      if opts.save_to_temp_register then
+  if opts.save_to_temp_register then
+    vim.api.nvim_create_autocmd("BufWinLeave", {
+      buffer = popup.bufnr,
+      callback = function()
         local text = u.get_buffer_text(popup.bufnr)
         for _, register in ipairs(M.settings.popup.temp_registers) do
           vim.fn.setreg(register, text)
         end
-      end
-      exit(popup, opts)
-    end,
-  })
+      end,
+    })
+  end
+
+  if opts.action_before_exit then
+    vim.api.nvim_create_autocmd("BufWinLeave", {
+      buffer = popup.bufnr,
+      callback = function()
+        exit(popup, opts)
+      end,
+    })
+  end
 end
 
 -- Dependencies


### PR DESCRIPTION
This PR addresses #308.

The code for closing popups is quite complicated, so it would still benefit from a refactor. The `popup:unmount()` methods are called necessarily several times. This PR gets rid at least of some of these repeated calls and it also gets rid of the call to `vim.api.nvim_buf_delete()` in favour of the existing `exit(popup, opts)` function which has the advantage that the `nui` library makes sure there is something to be unmounted when `layout:unmount` or `popup:unmount` are called.

This PR also limits the `BufWinLeave` autocommands to just the buffers that actually need them.