### PR TITLE
Fix docs: choose_merge_request's open_reviewer default value is true

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -635,7 +635,7 @@ This command will automatically check out that branch locally, and optionally
 open the reviewer pane. This is the default behavior.
 >lua
   require("gitlab").choose_merge_request()
-  require("gitlab").choose_merge_request({ open_reviewer = false })
+  require("gitlab").choose_merge_request({ open_reviewer = true })
 <
     Parameters: ~
         • {opts}: (table|nil) Keyword arguments to configure the checkout.


### PR DESCRIPTION
Hi Harry,
Thanks so much for writing this plugin. I've recently started a job at a company that uses Gitlab so I'm giving it a go. I noticed that the default value of `open_reviewer` when calling `choose_merge_request` was wrong in the docs, so here's a tiny PR to fix it.
Cheers!