### PR TITLE
Feat: Add branch info to choose_merge_request menu

### DIFF
--- a/lua/gitlab/actions/merge_requests.lua
+++ b/lua/gitlab/actions/merge_requests.lua
@@ -25,7 +25,7 @@ M.choose_merge_request = function(opts)
   vim.ui.select(state.MERGE_REQUESTS, {
     prompt = "Choose Merge Request",
     format_item = function(mr)
-      return string.format("%s (%s)", mr.title, mr.author.name)
+      return string.format("%s [%s -> %s] (%s)", mr.title, mr.source_branch, mr.target_branch, mr.author.name)
     end,
   }, function(choice)
     if not choice then


### PR DESCRIPTION
When choosing a merge request, I usually want to also see what branch is being merge into what target branch. This PR adds this information to the MR select menu.