### PR TITLE
Chore: Add heart emoji

### DIFF
--- a/config/emojis.json
+++ b/config/emojis.json
@@ -3432,6 +3432,54 @@
     ],
     "moji": "🤕"
   },
+  "heart": {
+    "unicode": "1F495",
+    "unicode_alternates": [],
+    "name": "heart",
+    "shortname": ":heart:",
+    "category": "people",
+    "aliases": [],
+    "aliases_ascii": [],
+    "keywords": [
+      "affection",
+      "crush",
+      "face",
+      "infatuation",
+      "like",
+      "love",
+      "valentines",
+      "heart",
+      "lovestruck",
+      "heart-shaped",
+      "emotion",
+      "beautiful"
+    ],
+    "moji": "❤️ "
+  },
+  "hearts": {
+    "unicode": "1F495",
+    "unicode_alternates": [],
+    "name": "hearts",
+    "shortname": ":hearts:",
+    "category": "people",
+    "aliases": [],
+    "aliases_ascii": [],
+    "keywords": [
+      "affection",
+      "crush",
+      "face",
+      "infatuation",
+      "like",
+      "love",
+      "valentines",
+      "heart",
+      "lovestruck",
+      "heart-shaped",
+      "emotion",
+      "beautiful"
+    ],
+    "moji": "❤️ "
+  },
   "heart_eyes": {
     "unicode": "1F60D",
     "unicode_alternates": [],


### PR DESCRIPTION
Hi @harrisoncramer, I've noticed that simple `:hearts:` and `:heart:` emojis are missing in the list of supported emojis. I don't think you created the `config/emojis.json` by hand so maybe you don't expect the file to be modified manually. In any case, it would be nice to add these emojis.

The extra spaces in the `"moji"` fields are there on purpose, so that Neovim renders the symbols with adequate spacing.