### PR TITLE
chore(docs): add keybindings in README for which-key users

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,43 @@ For a list of all these settings please run `:h gitlab.nvim.configuring-the-plug
 
 The plugin sets up a number of useful keybindings in the special buffers it creates, and some global keybindings as well. Refer to the relevant section of the manual `:h gitlab.nvim.keybindings` for more details.
 
+### Or if you are using [which-key](https://github.com/folke/which-key.nvim), here's what you can use:
+
+```lua
+local wk = require("which-key")
+local gitlab = require("gitlab")
+
+wk.register({
+    ["lb"] = { gitlab.choose_merge_request, "choose_merge_request" },
+    ["lr"] = { gitlab.review, "review" },
+    ["ls"] = { gitlab.summary, "summary" },
+    ["lA"] = { gitlab.approve, "approve" },
+    ["lR"] = { gitlab.revoke, "revoke" },
+    ["lc"] = { gitlab.create_comment, "create_comment" },
+    ["lO"] = { gitlab.create_mr, "create_mr" },
+    ["lm"] = { gitlab.move_to_discussion_tree_from_diagnostic, "move_to_discussion_tree_from_diagnostic" },
+    ["ln"] = { gitlab.create_note, "create_note" },
+    ["ld"] = { gitlab.toggle_discussions, "toggle_discussions" },
+    ["laa"] = { gitlab.add_assignee, "add_assignee" },
+    ["lad"] = { gitlab.delete_assignee, "delete_assignee" },
+    ["lla"] = { gitlab.add_label, "add_label" },
+    ["lld"] = { gitlab.delete_label, "delete_label" },
+    ["lra"] = { gitlab.add_reviewer, "add_reviewer" },
+    ["lrd"] = { gitlab.delete_reviewer, "delete_reviewer" },
+    ["lp"] = { gitlab.pipeline, "pipeline" },
+    ["lo"] = { gitlab.open_in_browser, "open_in_browser" },
+    ["lM"] = { gitlab.merge, "merge" },
+    ["lu"] = { gitlab.copy_mr_url, "copy_mr_url" },
+    ["lP"] = { gitlab.publish_all_drafts, "publish_all_drafts" },
+    ["lD"] = { gitlab.toggle_draft_mode, "toggle_draft_mode" },
+}, { prefix = "g", mode = "n" })
+
+wk.register({
+    ["lc"] = { gitlab.create_multiline_comment, "create_multiline_comment" },
+    ["lC"] = { gitlab.create_comment_suggestion, "create_comment_suggestion" },
+}, { prefix = "g", mode = "v" })
+```
+
 For more information about each of these commands, and about the APIs in general, run `:h gitlab.nvim.api`
 
 ## Contributing

--- a/cmd/merge_requests.go
+++ b/cmd/merge_requests.go
@@ -3,11 +3,17 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"fmt"
 	"net/http"
 
 	"github.com/xanzy/go-gitlab"
 )
+
+type ListMergeRequestRequest struct {
+  Label []string `json:"label"`
+  NotLabel []string `json:"notlabel"`
+}
 
 type ListMergeRequestResponse struct {
 	SuccessResponse
@@ -15,16 +21,32 @@ type ListMergeRequestResponse struct {
 }
 
 func (a *api) mergeRequestsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method != http.MethodPost {
+		w.Header().Set("Access-Control-Allow-Methods", http.MethodPost)
+		handleError(w, InvalidRequestError{}, "Expected POST", http.StatusMethodNotAllowed)
+		return
+	}
 
-	if r.Method != http.MethodGet {
-		w.Header().Set("Access-Control-Allow-Methods", http.MethodGet)
-		handleError(w, InvalidRequestError{}, "Expected GET", http.StatusMethodNotAllowed)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		handleError(w, err, "Could not read request body", http.StatusBadRequest)
+		return
+	}
+
+	defer r.Body.Close()
+  var listMergeRequestRequest ListMergeRequestRequest 
+  err = json.Unmarshal(body, &listMergeRequestRequest)
+	if err != nil {
+		handleError(w, err, "Could not read JSON from request", http.StatusBadRequest)
 		return
 	}
 
 	options := gitlab.ListProjectMergeRequestsOptions{
 		Scope: gitlab.Ptr("all"),
 		State: gitlab.Ptr("opened"),
+    Labels: (*gitlab.LabelOptions)(&listMergeRequestRequest.Label),
+    NotLabels: (*gitlab.LabelOptions)(&listMergeRequestRequest.NotLabel),
 	}
 
 	mergeRequests, _, err := a.client.ListProjectMergeRequests(a.projectInfo.ProjectId, &options)
@@ -32,7 +54,6 @@ func (a *api) mergeRequestsHandler(w http.ResponseWriter, r *http.Request) {
 		handleError(w, fmt.Errorf("Failed to list merge requests: %w", err), "Failed to list merge requests", http.StatusInternalServerError)
 		return
 	}
-
 	if len(mergeRequests) == 0 {
 		handleError(w, errors.New("No merge requests found"), "No merge requests found", http.StatusNotFound)
 		return
@@ -51,5 +72,4 @@ func (a *api) mergeRequestsHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		handleError(w, err, "Could not encode response", http.StatusInternalServerError)
 	}
-
 }

--- a/lua/gitlab/async.lua
+++ b/lua/gitlab/async.lua
@@ -36,7 +36,7 @@ function async:fetch(dependencies, i, argTable)
   end
 
   -- Call the API, set the data, and then call the next API
-  local body = dependency.body and dependency.body() or nil
+  local body = dependency.body and dependency.body(argTable) or nil
   job.run_job(dependency.endpoint, dependency.method or "GET", body, function(data)
     state[dependency.state] = dependency.key and data[dependency.key] or data
     self:fetch(dependencies, i + 1, argTable)

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -616,7 +616,17 @@ M.dependencies = {
     endpoint = "/merge_requests",
     key = "merge_requests",
     state = "MERGE_REQUESTS",
-    refresh = false,
+    refresh = true,
+    method = "POST",
+    body = function(argTable)
+      local listArgs = {
+        thishastobehereorelsethiswillbeinterpretedasanarray = {}
+      }
+      for k,v in pairs(argTable or {}) do
+        listArgs[k] = v
+      end
+      return listArgs
+    end
   },
   discussion_data = {
     -- key is missing here...


### PR DESCRIPTION
I added these for better DX, because I don't think it's possible for devs to remember all these available feature. 
With `which-key`, the user should be able to see what each keybinding does.

---
This plugin is awesome, and very helpful.

I sure hope a lot of people will contribute to your project @harrisoncramer !