### PR TITLE
Fix: Discussion tree highlighting

### DIFF
--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -11,10 +11,10 @@ highlight link Unresolved GitlabUnresolved
 execute 'syntax match Resolved /\s' . g:gitlab_discussion_tree_resolved . '\s\?/'
 highlight link Resolved GitlabResolved
 
-execute 'syntax match GitlabDiscussionOpen /^' . g:gitlab_discussion_tree_expander_open . '/'
+execute 'syntax match GitlabDiscussionOpen /^\s*' . g:gitlab_discussion_tree_expander_open . '/'
 highlight link GitlabDiscussionOpen GitlabExpander
 
-execute 'syntax match GitlabDiscussionClosed /^' . g:gitlab_discussion_tree_expander_closed . '/'
+execute 'syntax match GitlabDiscussionClosed /^\s*' . g:gitlab_discussion_tree_expander_closed . '/'
 highlight link GitlabDiscussionClosed GitlabExpander
 
 execute 'syntax match Draft /' . g:gitlab_discussion_tree_draft . '/'

--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -23,4 +23,4 @@ highlight link Draft GitlabDraft
 execute 'syntax match Username "@[a-zA-Z0-9.]\+"'
 highlight link Username GitlabUsername
 
-let b:current_syntax = "gitlab"
+let b:current_syntax = 'gitlab'

--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -20,7 +20,7 @@ highlight link GitlabDiscussionClosed GitlabExpander
 execute 'syntax match Draft /' . g:gitlab_discussion_tree_draft . '/'
 highlight link Draft GitlabDraft
 
-execute 'syntax match Username "@\w\+"'
+execute 'syntax match Username "@[a-zA-Z0-9.]\+"'
 highlight link Username GitlabUsername
 
 let b:current_syntax = "gitlab"

--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -23,4 +23,8 @@ highlight link Draft GitlabDraft
 execute 'syntax match Username "@[a-zA-Z0-9.]\+"'
 highlight link Username GitlabUsername
 
+execute 'syntax match Mention "\%(' . g:gitlab_discussion_tree_expander_open . '\|'
+  \ . g:gitlab_discussion_tree_expander_closed . '\)\@<!@[a-zA-Z0-9.]*"'
+highlight link Mention GitlabMention
+
 let b:current_syntax = 'gitlab'


### PR DESCRIPTION
#339 introduced some regressions in discussion tree highlighting. This PR fixes:
1. expander highlighting in sub-nodes
2. highlighting of usernames with dots (e.g., `@name.surname`)
3. separate highlighting for mentions (different from `GitlabUsername`)