### PR TITLE
Fix: Error with removed config fields

### DIFF
--- a/lua/gitlab/health.lua
+++ b/lua/gitlab/health.lua
@@ -111,7 +111,7 @@ M.check = function(return_results)
 
   for _, field in ipairs(removed_settings_fields) do
     if u.get_nested_field(state.settings, field) ~= nil then
-      vim.health.warn(warnings, field)
+      table.insert(removed_fields_in_user_config, field)
     end
   end
 


### PR DESCRIPTION
Hi @harrisoncramer, I didn't have the time to react to your [comment](https://github.com/harrisoncramer/gitlab.nvim/pull/345#issuecomment-2291539147) on your initial MR for the health check. Now that I've given it a try, I've found a bug in the check for removed config fields, so here's a fix.