### PR TITLE
Feat: Enable always jumping to discussion tree

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -155,10 +155,7 @@ you call this function with no values the defaults will be used:
       debug = { go_request = false, go_response = false }, -- Which values to log
       attachment_dir = nil, -- The local directory for files (see the "summary" section)
       reviewer_settings = {
-        no_diagnostic_actions = { -- What to do when pressing `move_to_discussion_tree` keybinding on line with no diagnostic.
-          warn = true, -- Show a warning if true, otherwise do nothing.
-          jump = true, -- Jump to last position in discussion tree if true, otherwise stay in reviewer.
-        },
+        jump_with_no_diagnostics = false, -- Jump to last position in discussion tree if true, otherwise stay in reviewer and show warning.
         diffview = {
           imply_local = false, -- If true, will attempt to use --imply_local option when calling |:DiffviewOpen|
         },

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -155,6 +155,10 @@ you call this function with no values the defaults will be used:
       debug = { go_request = false, go_response = false }, -- Which values to log
       attachment_dir = nil, -- The local directory for files (see the "summary" section)
       reviewer_settings = {
+        no_diagnostic_actions = { -- What to do when pressing `move_to_discussion_tree` keybinding on line with no diagnostic.
+          warn = true, -- Show a warning if true, otherwise do nothing.
+          jump = true, -- Jump to last position in discussion tree if true, otherwise stay in reviewer.
+        },
         diffview = {
           imply_local = false, -- If true, will attempt to use --imply_local option when calling |:DiffviewOpen|
         },

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -202,14 +202,11 @@ M.move_to_discussion_tree = function()
   end
 
   if #d == 0 then
-    local warning = "No diagnostics for this line."
-    if state.settings.reviewer_settings.no_diagnostic_actions.jump then
-      warning = warning .. " Jumping to last position in discussion tree."
+    if state.settings.reviewer_settings.jump_with_no_diagnostics then
       vim.api.nvim_win_set_cursor(M.split.winid, { M.last_row, M.last_column })
       vim.api.nvim_set_current_win(M.split.winid)
-    end
-    if state.settings.reviewer_settings.no_diagnostic_actions.warn then
-      u.notify(warning, vim.log.levels.WARN)
+    else
+      u.notify("No diagnostics for this line.", vim.log.levels.WARN)
     end
     return
   elseif #d > 1 then

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -52,6 +52,10 @@ M.settings = {
   config_path = nil,
   reviewer = "diffview",
   reviewer_settings = {
+    no_diagnostic_actions = {
+      warn = true,
+      jump = true,
+    },
     diffview = {
       imply_local = false,
     },

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -52,10 +52,7 @@ M.settings = {
   config_path = nil,
   reviewer = "diffview",
   reviewer_settings = {
-    no_diagnostic_actions = {
-      warn = true,
-      jump = true,
-    },
+    jump_with_no_diagnostics = false,
     diffview = {
       imply_local = false,
     },


### PR DESCRIPTION
This PR makes it possible to customize the behavior when pressing the `move_to_discussion_tree` keybinding in the reviewer and there is no diagnostic under the cursor. Users can now set up any combination of:
- show warning
- jump to last position in discussion tree

Closes #309.