### PR TITLE
feat: Improve MR selection

### DIFF
--- a/cmd/app/label.go
+++ b/cmd/app/label.go
@@ -52,7 +52,7 @@ func (a labelService) handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (a labelService) getLabels(w http.ResponseWriter, r *http.Request) {
+func (a labelService) getLabels(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	labels, res, err := a.client.ListLabels(a.projectInfo.ProjectId, &gitlab.ListLabelsOptions{})

--- a/cmd/app/merge_requests.go
+++ b/cmd/app/merge_requests.go
@@ -10,8 +10,9 @@ import (
 )
 
 type ListMergeRequestRequest struct {
-	Label    []string `json:"label"`
-	NotLabel []string `json:"notlabel"`
+	Label    *gitlab.LabelOptions `json:"label"`
+	NotLabel *gitlab.LabelOptions `json:"notlabel"`
+	State    *string              `json:"state,omitempty"`
 }
 
 type ListMergeRequestResponse struct {
@@ -50,11 +51,15 @@ func (a mergeRequestListerService) handler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if listMergeRequestRequest.State == nil {
+		listMergeRequestRequest.State = gitlab.Ptr("opened")
+	}
+
 	options := gitlab.ListProjectMergeRequestsOptions{
 		Scope:     gitlab.Ptr("all"),
-		State:     gitlab.Ptr("opened"),
-		Labels:    (*gitlab.LabelOptions)(&listMergeRequestRequest.Label),
-		NotLabels: (*gitlab.LabelOptions)(&listMergeRequestRequest.NotLabel),
+		State:     listMergeRequestRequest.State,
+		Labels:    listMergeRequestRequest.Label,
+		NotLabels: listMergeRequestRequest.NotLabel,
 	}
 
 	mergeRequests, res, err := a.client.ListProjectMergeRequests(a.projectInfo.ProjectId, &options)

--- a/cmd/app/merge_requests_test.go
+++ b/cmd/app/merge_requests_test.go
@@ -26,7 +26,7 @@ func (f fakeMergeRequestLister) ListProjectMergeRequests(pid interface{}, opt *g
 }
 
 func TestMergeRequestHandler(t *testing.T) {
-	var testListMergeRequestsRequest = ListMergeRequestRequest{Label: []string{}, NotLabel: []string{}}
+	var testListMergeRequestsRequest = gitlab.ListProjectMergeRequestsOptions{}
 	t.Run("Should fetch merge requests", func(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests", testListMergeRequestsRequest)
 		svc := mergeRequestListerService{testProjectData, fakeMergeRequestLister{}}

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -166,7 +166,6 @@ func withMr(svc ServiceWithHandler, c data, client MergeRequestLister) http.Hand
 		if c.projectInfo.MergeId == 0 {
 			options := gitlab.ListProjectMergeRequestsOptions{
 				Scope:        gitlab.Ptr("all"),
-				State:        gitlab.Ptr("opened"),
 				SourceBranch: &c.gitInfo.BranchName,
 				TargetBranch: pluginOptions.ChosenTargetBranch,
 			}

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -739,22 +739,25 @@ Choose a merge request from a list of those open in your current project to
 review. This command will automatically check out the feature branch locally
 and open the reviewer pane (this can be overridden with the `open_reviewer`
 parameter.
+
 You can also filter merge requests by specifying `label` and `notlabel`
-parameters.
+parameters, or any other parameter included in list MRs API.
+
+By default, the endpoint will return all open merge requests.
 >lua
   require("gitlab").choose_merge_request()
   require("gitlab").choose_merge_request({ open_reviewer = false })
-  require("gitlab").choose_merge_request({ label = {"include_mrs_with_label"} })
-  require("gitlab").choose_merge_request({ notlabel = {"exclude_mrs_with_label"} })
+  require("gitlab").choose_merge_request({ labels = {"include_mrs_with_label"} })
+  require("gitlab").choose_merge_request({ not_labels = {"exclude_mrs_with_label"} })
 <
     Parameters: ~
         • {opts}: (table|nil) Keyword arguments to configure the checkout.
             • {open_reviewer}: (boolean) Whether to open the reviewer after
             switching branches. True by default.
-            • {label}: (table<string>) Return merge requests with *including* matching labels
-            • {notlabel}: (table<string>) Return merge requests *excluding*
+            • {labels}: (table<string>) Return merge requests with *including* matching labels
+            • {not_labels}: (table<string>) Return merge requests *excluding*
               matching label
-<
+            • Etc, see: https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests
                                                                 *gitlab.nvim.review*
 gitlab.review() ~
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -748,15 +748,13 @@ By default, the endpoint will return all open merge requests.
   require("gitlab").choose_merge_request()
   require("gitlab").choose_merge_request({ open_reviewer = false })
   require("gitlab").choose_merge_request({ labels = {"include_mrs_with_label"} })
-  require("gitlab").choose_merge_request({ not_labels = {"exclude_mrs_with_label"} })
+  require("gitlab").choose_merge_request({ ["[not]labels"] = {"exclude_mrs_with_label"} })
 <
     Parameters: ~
         • {opts}: (table|nil) Keyword arguments to configure the checkout.
             • {open_reviewer}: (boolean) Whether to open the reviewer after
             switching branches. True by default.
             • {labels}: (table<string>) Return merge requests with *including* matching labels
-            • {not_labels}: (table<string>) Return merge requests *excluding*
-              matching label
             • Etc, see: https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests
                                                                 *gitlab.nvim.review*
 gitlab.review() ~

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -67,13 +67,11 @@ M.open = function()
   end
 
   if state.INFO.state == "closed" then
-    u.notify(string.format("This MR was closed on %s", u.format_date(state.INFO.closed_at)),
-      vim.log.levels.WARN)
+    u.notify(string.format("This MR was closed on %s", u.format_date(state.INFO.closed_at)), vim.log.levels.WARN)
   end
 
   if state.INFO.state == "merged" then
-    u.notify(string.format("This MR was merged on %s", u.format_date(state.INFO.merged_at)),
-      vim.log.levels.WARN)
+    u.notify(string.format("This MR was merged on %s", u.format_date(state.INFO.merged_at)), vim.log.levels.WARN)
   end
 
   if state.settings.discussion_diagnostic ~= nil or state.settings.discussion_sign ~= nil then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -66,6 +66,11 @@ M.open = function()
     u.notify("This merge request has conflicts!", vim.log.levels.WARN)
   end
 
+  if state.INFO.state == "closed" then
+    u.notify(string.format("This MR was closed on %s", u.format_date(state.INFO.closed_at)),
+      vim.log.levels.WARN)
+  end
+
   if state.settings.discussion_diagnostic ~= nil or state.settings.discussion_sign ~= nil then
     u.notify(
       "Diagnostics are now configured as settings.discussion_signs, see :h gitlab.nvim.signs-and-diagnostics",

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -67,12 +67,12 @@ M.open = function()
   end
 
   if state.INFO.state == "closed" then
-    u.notify(string.format("This was closed on %s", u.format_date(state.INFO.closed_at)),
+    u.notify(string.format("This MR was closed on %s", u.format_date(state.INFO.closed_at)),
       vim.log.levels.WARN)
   end
 
   if state.INFO.state == "merged" then
-    u.notify(string.format("This was merged on %s", u.format_date(state.INFO.merged_at)),
+    u.notify(string.format("This MR was merged on %s", u.format_date(state.INFO.merged_at)),
       vim.log.levels.WARN)
   end
 

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -67,7 +67,12 @@ M.open = function()
   end
 
   if state.INFO.state == "closed" then
-    u.notify(string.format("This MR was closed on %s", u.format_date(state.INFO.closed_at)),
+    u.notify(string.format("This was closed on %s", u.format_date(state.INFO.closed_at)),
+      vim.log.levels.WARN)
+  end
+
+  if state.INFO.state == "merged" then
+    u.notify(string.format("This was merged on %s", u.format_date(state.INFO.merged_at)),
       vim.log.levels.WARN)
   end
 

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -565,6 +565,9 @@ M.dependencies = {
     refresh = true,
     method = "POST",
     body = function(opts)
+      if opts then
+        opts.open_reviewer_field = nil
+      end
       return opts or vim.json.decode('{}')
     end,
   },

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -566,8 +566,8 @@ M.dependencies = {
     method = "POST",
     body = function(opts)
       local listArgs = {
-        label = opts and opts.label or {},
-        notlabel = opts and opts.notlabel or {},
+        labels = opts and opts.labels or {},
+        ["not[labels]"] = opts and opts.not_labels or {},
       }
       for k, v in pairs(listArgs) do
         listArgs[k] = v

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -565,14 +565,7 @@ M.dependencies = {
     refresh = true,
     method = "POST",
     body = function(opts)
-      local listArgs = {
-        labels = opts and opts.labels or {},
-        ["not[labels]"] = opts and opts.not_labels or {},
-      }
-      for k, v in pairs(listArgs) do
-        listArgs[k] = v
-      end
-      return listArgs
+      return opts or vim.json.decode('{}')
     end,
   },
   discussion_data = {

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -568,11 +568,14 @@ M.dependencies = {
       if opts then
         opts.open_reviewer_field = nil
       end
+      if opts.notlabel then -- Legacy: Migrate use of notlabel to not[label], per API
+        opts["not[label]"] = opts.notlabel
+        opts.notlabel = nil
+      end
       return opts or vim.json.decode('{}')
     end,
   },
   discussion_data = {
-    -- key is missing here...
     endpoint = "/mr/discussions/list",
     state = "DISCUSSION_DATA",
     refresh = false,

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -572,7 +572,7 @@ M.dependencies = {
         opts["not[label]"] = opts.notlabel
         opts.notlabel = nil
       end
-      return opts or vim.json.decode('{}')
+      return opts or vim.json.decode("{}")
     end,
   },
   discussion_data = {


### PR DESCRIPTION
This MR makes it possible to query for MRs that have already been merged or closed, among a variety of other query parameters.

The full list of query options can be found here: https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests

Unfortunately Gitlab's API does not support the use of OR operators, which means that it's not possible to perform queries such as "Give me all MRs that have me as an assignee OR a reviewer OR an author" which would be useful. I'm considering adding this into the plugin, and aggregating the results from these API calls running in parallel, but may do that as a separate MR.

Addresses #321 