### PR TITLE
Fix: Comment on single line selects two lines

### DIFF
--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -303,7 +303,7 @@ local set_keymaps = function(bufnr, keymaps)
   if keymaps.reviewer.create_comment ~= false then
     -- Set keymap for repeated operator keybinding
     vim.keymap.set("o", keymaps.reviewer.create_comment, function()
-      vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { tostring(vim.v.count1) .. "j" } }, {})
+      vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { tostring(vim.v.count1) .. "$" } }, {})
     end, {
       buffer = bufnr,
       desc = "Create comment for [count] lines",
@@ -333,7 +333,7 @@ local set_keymaps = function(bufnr, keymaps)
   if keymaps.reviewer.create_suggestion ~= false then
     -- Set keymap for repeated operator keybinding
     vim.keymap.set("o", keymaps.reviewer.create_suggestion, function()
-      vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { tostring(vim.v.count1) .. "j" } }, {})
+      vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { tostring(vim.v.count1) .. "$" } }, {})
     end, {
       buffer = bufnr,
       desc = "Create suggestion for [count] lines",


### PR DESCRIPTION
This PR fixes a bug I introduced in the default keybindings for commenting (with or without a suggestion) on a single line.
Fixes #370.