### PR TITLE
fix: Fixes issues w/ shared pointers to structs

### DIFF
--- a/cmd/app/assignee_test.go
+++ b/cmd/app/assignee_test.go
@@ -27,7 +27,7 @@ func TestAssigneeHandler(t *testing.T) {
 		svc := middleware(
 			assigneesService{testProjectData, fakeAssigneeClient{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &AssigneeUpdateRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[AssigneeUpdateRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		data := getSuccessData(t, svc, request)
@@ -40,7 +40,7 @@ func TestAssigneeHandler(t *testing.T) {
 		svc := middleware(
 			assigneesService{testProjectData, client},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &AssigneeUpdateRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[AssigneeUpdateRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -53,7 +53,7 @@ func TestAssigneeHandler(t *testing.T) {
 		svc := middleware(
 			assigneesService{testProjectData, client},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &AssigneeUpdateRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[AssigneeUpdateRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/attachment_test.go
+++ b/cmd/app/attachment_test.go
@@ -38,7 +38,7 @@ func TestAttachmentHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/attachment", attachmentTestRequestData)
 		svc := middleware(
 			attachmentService{testProjectData, fakeFileReader{}, fakeFileUploaderClient{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &AttachmentRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AttachmentRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -49,7 +49,7 @@ func TestAttachmentHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/attachment", attachmentTestRequestData)
 		svc := middleware(
 			attachmentService{testProjectData, fakeFileReader{}, fakeFileUploaderClient{testBase{errFromGitlab: true}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &AttachmentRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AttachmentRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -60,7 +60,7 @@ func TestAttachmentHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/attachment", attachmentTestRequestData)
 		svc := middleware(
 			attachmentService{testProjectData, fakeFileReader{}, fakeFileUploaderClient{testBase{status: http.StatusSeeOther}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &AttachmentRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AttachmentRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/comment_test.go
+++ b/cmd/app/comment_test.go
@@ -44,9 +44,9 @@ func TestPostComment(t *testing.T) {
 			commentService{testProjectData, fakeCommentClient{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:   &PostCommentRequest{},
-				http.MethodDelete: &DeleteCommentRequest{},
-				http.MethodPatch:  &EditCommentRequest{},
+				http.MethodPost:   newPayload[PostCommentRequest],
+				http.MethodDelete: newPayload[DeleteCommentRequest],
+				http.MethodPatch:  newPayload[EditCommentRequest],
 			}),
 			withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 		)
@@ -66,9 +66,9 @@ func TestPostComment(t *testing.T) {
 			commentService{testProjectData, fakeCommentClient{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:   &PostCommentRequest{},
-				http.MethodDelete: &DeleteCommentRequest{},
-				http.MethodPatch:  &EditCommentRequest{},
+				http.MethodPost:   newPayload[PostCommentRequest],
+				http.MethodDelete: newPayload[DeleteCommentRequest],
+				http.MethodPatch:  newPayload[EditCommentRequest],
 			}),
 			withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 		)
@@ -82,9 +82,9 @@ func TestPostComment(t *testing.T) {
 			commentService{testProjectData, fakeCommentClient{testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:   &PostCommentRequest{},
-				http.MethodDelete: &DeleteCommentRequest{},
-				http.MethodPatch:  &EditCommentRequest{},
+				http.MethodPost:   newPayload[PostCommentRequest],
+				http.MethodDelete: newPayload[DeleteCommentRequest],
+				http.MethodPatch:  newPayload[EditCommentRequest],
 			}),
 			withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 		)
@@ -98,9 +98,9 @@ func TestPostComment(t *testing.T) {
 			commentService{testProjectData, fakeCommentClient{testBase{status: http.StatusSeeOther}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:   &PostCommentRequest{},
-				http.MethodDelete: &DeleteCommentRequest{},
-				http.MethodPatch:  &EditCommentRequest{},
+				http.MethodPost:   newPayload[PostCommentRequest],
+				http.MethodDelete: newPayload[DeleteCommentRequest],
+				http.MethodPatch:  newPayload[EditCommentRequest],
 			}),
 			withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 		)
@@ -117,9 +117,9 @@ func TestDeleteComment(t *testing.T) {
 			commentService{testProjectData, fakeCommentClient{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:   &PostCommentRequest{},
-				http.MethodDelete: &DeleteCommentRequest{},
-				http.MethodPatch:  &EditCommentRequest{},
+				http.MethodPost:   newPayload[PostCommentRequest],
+				http.MethodDelete: newPayload[DeleteCommentRequest],
+				http.MethodPatch:  newPayload[EditCommentRequest],
 			}),
 			withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 		)
@@ -136,9 +136,9 @@ func TestEditComment(t *testing.T) {
 			commentService{testProjectData, fakeCommentClient{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:   &PostCommentRequest{},
-				http.MethodDelete: &DeleteCommentRequest{},
-				http.MethodPatch:  &EditCommentRequest{},
+				http.MethodPost:   newPayload[PostCommentRequest],
+				http.MethodDelete: newPayload[DeleteCommentRequest],
+				http.MethodPatch:  newPayload[EditCommentRequest],
 			}),
 			withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 		)

--- a/cmd/app/create_mr_test.go
+++ b/cmd/app/create_mr_test.go
@@ -31,7 +31,7 @@ func TestCreateMr(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/create_mr", testCreateMrRequestData)
 		svc := middleware(
 			mergeRequestCreatorService{testProjectData, fakeMergeCreatorClient{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &CreateMrRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[CreateMrRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -42,7 +42,7 @@ func TestCreateMr(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/create_mr", testCreateMrRequestData)
 		svc := middleware(
 			mergeRequestCreatorService{testProjectData, fakeMergeCreatorClient{testBase{errFromGitlab: true}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &CreateMrRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[CreateMrRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -53,7 +53,7 @@ func TestCreateMr(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/create_mr", testCreateMrRequestData)
 		svc := middleware(
 			mergeRequestCreatorService{testProjectData, fakeMergeCreatorClient{testBase{status: http.StatusSeeOther}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &CreateMrRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[CreateMrRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -66,7 +66,7 @@ func TestCreateMr(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/create_mr", reqData)
 		svc := middleware(
 			mergeRequestCreatorService{testProjectData, fakeMergeCreatorClient{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &CreateMrRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[CreateMrRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -80,7 +80,7 @@ func TestCreateMr(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/create_mr", reqData)
 		svc := middleware(
 			mergeRequestCreatorService{testProjectData, fakeMergeCreatorClient{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &CreateMrRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[CreateMrRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/draft_note_publisher_test.go
+++ b/cmd/app/draft_note_publisher_test.go
@@ -25,7 +25,7 @@ func TestPublishDraftNote(t *testing.T) {
 		svc := middleware(
 			draftNotePublisherService{testProjectData, fakeDraftNotePublisher{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DraftNotePublishRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DraftNotePublishRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -36,7 +36,7 @@ func TestPublishDraftNote(t *testing.T) {
 		svc := middleware(
 			draftNotePublisherService{testProjectData, fakeDraftNotePublisher{testBase: testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DraftNotePublishRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DraftNotePublishRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -51,7 +51,7 @@ func TestPublishAllDraftNotes(t *testing.T) {
 		svc := middleware(
 			draftNotePublisherService{testProjectData, fakeDraftNotePublisher{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DraftNotePublishRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DraftNotePublishRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -62,7 +62,7 @@ func TestPublishAllDraftNotes(t *testing.T) {
 		svc := middleware(
 			draftNotePublisherService{testProjectData, fakeDraftNotePublisher{testBase: testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DraftNotePublishRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DraftNotePublishRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/draft_notes_test.go
+++ b/cmd/app/draft_notes_test.go
@@ -46,8 +46,8 @@ func TestListDraftNotes(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -61,8 +61,8 @@ func TestListDraftNotes(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{testBase: testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -75,8 +75,8 @@ func TestListDraftNotes(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{testBase: testBase{status: http.StatusSeeOther}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -96,8 +96,8 @@ func TestPostDraftNote(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -113,8 +113,8 @@ func TestDeleteDraftNote(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -127,8 +127,8 @@ func TestDeleteDraftNote(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -146,8 +146,8 @@ func TestEditDraftNote(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -160,8 +160,8 @@ func TestEditDraftNote(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)
@@ -177,8 +177,8 @@ func TestEditDraftNote(t *testing.T) {
 			draftNoteService{testProjectData, fakeDraftNoteManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost:  &PostDraftNoteRequest{},
-				http.MethodPatch: &UpdateDraftNoteRequest{},
+				http.MethodPost:  newPayload[PostDraftNoteRequest],
+				http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 			}),
 			withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 		)

--- a/cmd/app/job_test.go
+++ b/cmd/app/job_test.go
@@ -40,7 +40,7 @@ func TestJobHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodGet, "/job", JobTraceRequest{JobId: 3})
 		svc := middleware(
 			traceFileService{testProjectData, fakeTraceFileGetter{}},
-			withPayloadValidation(methodToPayload{http.MethodGet: &JobTraceRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodGet: newPayload[JobTraceRequest]}),
 			withMethodCheck(http.MethodGet),
 		)
 		data := getTraceFileData(t, svc, request)
@@ -51,7 +51,7 @@ func TestJobHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodGet, "/job", JobTraceRequest{JobId: 2})
 		svc := middleware(
 			traceFileService{testProjectData, fakeTraceFileGetter{testBase{errFromGitlab: true}}},
-			withPayloadValidation(methodToPayload{http.MethodGet: &JobTraceRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodGet: newPayload[JobTraceRequest]}),
 			withMethodCheck(http.MethodGet),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -62,7 +62,7 @@ func TestJobHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodGet, "/job", JobTraceRequest{JobId: 1})
 		svc := middleware(
 			traceFileService{testProjectData, fakeTraceFileGetter{testBase{status: http.StatusSeeOther}}},
-			withPayloadValidation(methodToPayload{http.MethodGet: &JobTraceRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodGet: newPayload[JobTraceRequest]}),
 			withMethodCheck(http.MethodGet),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/list_discussions_test.go
+++ b/cmd/app/list_discussions_test.go
@@ -71,7 +71,7 @@ func TestListDiscussions(t *testing.T) {
 		svc := middleware(
 			discussionsListerService{testProjectData, fakeDiscussionsLister{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DiscussionsRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getDiscussionsList(t, svc, request)
@@ -85,7 +85,7 @@ func TestListDiscussions(t *testing.T) {
 		svc := middleware(
 			discussionsListerService{testProjectData, fakeDiscussionsLister{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DiscussionsRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getDiscussionsList(t, svc, request)
@@ -98,7 +98,7 @@ func TestListDiscussions(t *testing.T) {
 		svc := middleware(
 			discussionsListerService{testProjectData, fakeDiscussionsLister{testBase: testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DiscussionsRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -109,7 +109,7 @@ func TestListDiscussions(t *testing.T) {
 		svc := middleware(
 			discussionsListerService{testProjectData, fakeDiscussionsLister{testBase: testBase{status: http.StatusSeeOther}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DiscussionsRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -120,7 +120,7 @@ func TestListDiscussions(t *testing.T) {
 		svc := middleware(
 			discussionsListerService{testProjectData, fakeDiscussionsLister{badEmojiResponse: true, testBase: testBase{}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &DiscussionsRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/merge_mr_test.go
+++ b/cmd/app/merge_mr_test.go
@@ -28,7 +28,7 @@ func TestAcceptAndMergeHandler(t *testing.T) {
 			mergeRequestAccepterService{testProjectData, fakeMergeRequestAccepter{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost: &AcceptMergeRequestRequest{},
+				http.MethodPost: newPayload[AcceptMergeRequestRequest],
 			}),
 			withMethodCheck(http.MethodPost),
 		)
@@ -41,7 +41,7 @@ func TestAcceptAndMergeHandler(t *testing.T) {
 			mergeRequestAccepterService{testProjectData, fakeMergeRequestAccepter{testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost: &AcceptMergeRequestRequest{},
+				http.MethodPost: newPayload[AcceptMergeRequestRequest],
 			}),
 			withMethodCheck(http.MethodPost),
 		)
@@ -54,7 +54,7 @@ func TestAcceptAndMergeHandler(t *testing.T) {
 			mergeRequestAccepterService{testProjectData, fakeMergeRequestAccepter{testBase{status: http.StatusSeeOther}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
 			withPayloadValidation(methodToPayload{
-				http.MethodPost: &AcceptMergeRequestRequest{},
+				http.MethodPost: newPayload[AcceptMergeRequestRequest],
 			}),
 			withMethodCheck(http.MethodPost),
 		)

--- a/cmd/app/merge_requests_by_username_test.go
+++ b/cmd/app/merge_requests_by_username_test.go
@@ -32,7 +32,7 @@ func TestListMergeRequestByUsername(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests_by_username", testListMrsByUsernamePayload)
 		svc := middleware(
 			mergeRequestListerByUsernameService{testProjectData, fakeMergeRequestListerByUsername{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -43,7 +43,7 @@ func TestListMergeRequestByUsername(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests_by_username", testListMrsByUsernamePayload)
 		svc := middleware(
 			mergeRequestListerByUsernameService{testProjectData, fakeMergeRequestListerByUsername{emptyResponse: true}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)
@@ -58,7 +58,7 @@ func TestListMergeRequestByUsername(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests_by_username", missingUsernamePayload)
 		svc := middleware(
 			mergeRequestListerByUsernameService{testProjectData, fakeMergeRequestListerByUsername{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)
@@ -73,7 +73,7 @@ func TestListMergeRequestByUsername(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests_by_username", missingUsernamePayload)
 		svc := middleware(
 			mergeRequestListerByUsernameService{testProjectData, fakeMergeRequestListerByUsername{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)
@@ -86,7 +86,7 @@ func TestListMergeRequestByUsername(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests_by_username", testListMrsByUsernamePayload)
 		svc := middleware(
 			mergeRequestListerByUsernameService{testProjectData, fakeMergeRequestListerByUsername{testBase: testBase{errFromGitlab: true}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)
@@ -99,7 +99,7 @@ func TestListMergeRequestByUsername(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests_by_username", testListMrsByUsernamePayload)
 		svc := middleware(
 			mergeRequestListerByUsernameService{testProjectData, fakeMergeRequestListerByUsername{testBase: testBase{status: http.StatusSeeOther}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)

--- a/cmd/app/merge_requests_test.go
+++ b/cmd/app/merge_requests_test.go
@@ -36,7 +36,7 @@ func TestMergeRequestHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests", testListMergeRequestsRequest)
 		svc := middleware(
 			mergeRequestListerService{testProjectData, fakeMergeRequestLister{}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &gitlab.ListProjectMergeRequestsOptions{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[gitlab.ListProjectMergeRequestsOptions]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -46,7 +46,7 @@ func TestMergeRequestHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests", testListMergeRequestsRequest)
 		svc := middleware(
 			mergeRequestListerService{testProjectData, fakeMergeRequestLister{testBase: testBase{errFromGitlab: true}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &gitlab.ListProjectMergeRequestsOptions{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[gitlab.ListProjectMergeRequestsOptions]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)
@@ -57,7 +57,7 @@ func TestMergeRequestHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests", testListMergeRequestsRequest)
 		svc := middleware(
 			mergeRequestListerService{testProjectData, fakeMergeRequestLister{testBase: testBase{status: http.StatusSeeOther}}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &gitlab.ListProjectMergeRequestsOptions{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[gitlab.ListProjectMergeRequestsOptions]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)
@@ -68,7 +68,7 @@ func TestMergeRequestHandler(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/merge_requests", testListMergeRequestsRequest)
 		svc := middleware(
 			mergeRequestListerService{testProjectData, fakeMergeRequestLister{emptyResponse: true}},
-			withPayloadValidation(methodToPayload{http.MethodPost: &gitlab.ListProjectMergeRequestsOptions{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[gitlab.ListProjectMergeRequestsOptions]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, status := getFailData(t, svc, request)

--- a/cmd/app/middleware_test.go
+++ b/cmd/app/middleware_test.go
@@ -97,7 +97,7 @@ func TestValidatorMiddleware(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/foo", FakePayload{}) // No Foo field
 		data, status := getFailData(t, middleware(
 			fakeHandler{},
-			withPayloadValidation(methodToPayload{http.MethodPost: &FakePayload{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[FakePayload]}),
 		), request)
 		assert(t, data.Message, "Invalid payload")
 		assert(t, data.Details, "Foo is required")
@@ -107,7 +107,7 @@ func TestValidatorMiddleware(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/foo", FakePayload{Foo: "Some payload"})
 		data := getSuccessData(t, middleware(
 			fakeHandler{},
-			withPayloadValidation(methodToPayload{http.MethodPost: &FakePayload{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[FakePayload]}),
 		), request)
 		assert(t, data.Message, "Some message")
 	})

--- a/cmd/app/reply_test.go
+++ b/cmd/app/reply_test.go
@@ -27,7 +27,7 @@ func TestReplyHandler(t *testing.T) {
 		svc := middleware(
 			replyService{testProjectData, fakeReplyManager{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &ReplyRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[ReplyRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data := getSuccessData(t, svc, request)
@@ -38,7 +38,7 @@ func TestReplyHandler(t *testing.T) {
 		svc := middleware(
 			replyService{testProjectData, fakeReplyManager{testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &ReplyRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[ReplyRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)
@@ -50,7 +50,7 @@ func TestReplyHandler(t *testing.T) {
 		svc := middleware(
 			replyService{testProjectData, fakeReplyManager{testBase{status: http.StatusSeeOther}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: &ReplyRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[ReplyRequest]}),
 			withMethodCheck(http.MethodPost),
 		)
 		data, _ := getFailData(t, svc, request)

--- a/cmd/app/resolve_discussion_test.go
+++ b/cmd/app/resolve_discussion_test.go
@@ -30,7 +30,7 @@ func TestResolveDiscussion(t *testing.T) {
 		svc := middleware(
 			discussionsResolutionService{testProjectData, fakeDiscussionResolver{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &DiscussionResolveRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[DiscussionResolveRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		request := makeRequest(t, http.MethodPut, "/mr/discussions/resolve", testResolveMergeRequestPayload)
@@ -44,7 +44,7 @@ func TestResolveDiscussion(t *testing.T) {
 		svc := middleware(
 			discussionsResolutionService{testProjectData, fakeDiscussionResolver{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &DiscussionResolveRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[DiscussionResolveRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		request := makeRequest(t, http.MethodPut, "/mr/discussions/resolve", payload)
@@ -58,7 +58,7 @@ func TestResolveDiscussion(t *testing.T) {
 		svc := middleware(
 			discussionsResolutionService{testProjectData, fakeDiscussionResolver{}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &DiscussionResolveRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[DiscussionResolveRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		request := makeRequest(t, http.MethodPut, "/mr/discussions/resolve", payload)
@@ -72,7 +72,7 @@ func TestResolveDiscussion(t *testing.T) {
 		svc := middleware(
 			discussionsResolutionService{testProjectData, fakeDiscussionResolver{testBase: testBase{errFromGitlab: true}}},
 			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPut: &DiscussionResolveRequest{}}),
+			withPayloadValidation(methodToPayload{http.MethodPut: newPayload[DiscussionResolveRequest]}),
 			withMethodCheck(http.MethodPut),
 		)
 		request := makeRequest(t, http.MethodPut, "/mr/discussions/resolve", testResolveMergeRequestPayload)

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -99,28 +99,28 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 		commentService{d, gitlabClient},
 		withMr(d, gitlabClient),
 		withPayloadValidation(methodToPayload{
-			http.MethodPost:   &PostCommentRequest{},
-			http.MethodDelete: &DeleteCommentRequest{},
-			http.MethodPatch:  &EditCommentRequest{},
+			http.MethodPost:   newPayload[PostCommentRequest],
+			http.MethodDelete: newPayload[DeleteCommentRequest],
+			http.MethodPatch:  newPayload[EditCommentRequest],
 		}),
 		withMethodCheck(http.MethodPost, http.MethodDelete, http.MethodPatch),
 	))
 	m.HandleFunc("/mr/merge", middleware(
 		mergeRequestAccepterService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPost: &AcceptMergeRequestRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AcceptMergeRequestRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/mr/discussions/list", middleware(
 		discussionsListerService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPost: &DiscussionsRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/mr/discussions/resolve", middleware(
 		discussionsResolutionService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPut: &DiscussionResolveRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPut: newPayload[DiscussionResolveRequest]}),
 		withMethodCheck(http.MethodPut),
 	))
 	m.HandleFunc("/mr/info", middleware(
@@ -131,19 +131,19 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 	m.HandleFunc("/mr/assignee", middleware(
 		assigneesService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPut: &AssigneeUpdateRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPut: newPayload[AssigneeUpdateRequest]}),
 		withMethodCheck(http.MethodPut),
 	))
 	m.HandleFunc("/mr/summary", middleware(
 		summaryService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPut: &SummaryUpdateRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPut: newPayload[SummaryUpdateRequest]}),
 		withMethodCheck(http.MethodPut),
 	))
 	m.HandleFunc("/mr/reviewer", middleware(
 		reviewerService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPut: &ReviewerUpdateRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPut: newPayload[ReviewerUpdateRequest]}),
 		withMethodCheck(http.MethodPut),
 	))
 	m.HandleFunc("/mr/revisions", middleware(
@@ -154,7 +154,7 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 	m.HandleFunc("/mr/reply", middleware(
 		replyService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPost: &ReplyRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[ReplyRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/mr/label", middleware(
@@ -175,15 +175,15 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 		draftNoteService{d, gitlabClient},
 		withMr(d, gitlabClient),
 		withPayloadValidation(methodToPayload{
-			http.MethodPost:  &PostDraftNoteRequest{},
-			http.MethodPatch: &UpdateDraftNoteRequest{},
+			http.MethodPost:  newPayload[PostDraftNoteRequest],
+			http.MethodPatch: newPayload[UpdateDraftNoteRequest],
 		}),
 		withMethodCheck(http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete),
 	))
 	m.HandleFunc("/mr/draft_notes/publish", middleware(
 		draftNotePublisherService{d, gitlabClient},
 		withMr(d, gitlabClient),
-		withPayloadValidation(methodToPayload{http.MethodPost: &DraftNotePublishRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DraftNotePublishRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/pipeline", middleware(
@@ -200,17 +200,17 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 	))
 	m.HandleFunc("/attachment", middleware(
 		attachmentService{data: d, client: gitlabClient, fileReader: attachmentReader{}},
-		withPayloadValidation(methodToPayload{http.MethodPost: &AttachmentRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AttachmentRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/create_mr", middleware(
 		mergeRequestCreatorService{d, gitlabClient},
-		withPayloadValidation(methodToPayload{http.MethodPost: &CreateMrRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[CreateMrRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/job", middleware(
 		traceFileService{d, gitlabClient},
-		withPayloadValidation(methodToPayload{http.MethodGet: &JobTraceRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodGet: newPayload[JobTraceRequest]}),
 		withMethodCheck(http.MethodGet),
 	))
 	m.HandleFunc("/project/members", middleware(
@@ -219,12 +219,12 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 	))
 	m.HandleFunc("/merge_requests", middleware(
 		mergeRequestListerService{d, gitlabClient},
-		withPayloadValidation(methodToPayload{http.MethodPost: &gitlab.ListProjectMergeRequestsOptions{}}), // TODO: How to validate external object
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[gitlab.ListProjectMergeRequestsOptions]}), // TODO: How to validate external object
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/merge_requests_by_username", middleware(
 		mergeRequestListerByUsernameService{d, gitlabClient},
-		withPayloadValidation(methodToPayload{http.MethodPost: &MergeRequestByUsernameRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[MergeRequestByUsernameRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 	m.HandleFunc("/shutdown", middleware(

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -229,7 +229,7 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 	))
 	m.HandleFunc("/shutdown", middleware(
 		*s,
-		withPayloadValidation(methodToPayload{http.MethodPost: &ShutdownRequest{}}),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[ShutdownRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
 

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -69,6 +69,8 @@ local confirm_create_comment = function(text, visual_range, unlinked, discussion
     return
   end
 
+  vim.print("Here: ", unlinked, discussion_id)
+
   local reviewer_data = reviewer.get_reviewer_data()
   if reviewer_data == nil then
     u.notify("Error getting reviewer data", vim.log.levels.ERROR)
@@ -255,6 +257,7 @@ end
 --- This function will open a comment popup in order to create a comment on the changed/updated
 --- line in the current MR
 M.create_comment = function()
+  vim.print("Creating comment...")
   local has_clean_tree, err = git.has_clean_tree()
   if err ~= nil then
     return
@@ -298,6 +301,7 @@ end
 --- This function will open a a popup to create a "note" (e.g. unlinked comment)
 --- on the changed/updated line in the current MR
 M.create_note = function()
+  vim.print("Creating note...")
   local layout = M.create_comment_layout({ ranged = false, unlinked = true })
   if layout ~= nil then
     layout:mount()


### PR DESCRIPTION
I'd introduced a middleware pattern that was validating structs. The middleware was set up in the server with pointers to structs, like this:

```go
m.HandleFunc("/mr/merge", middleware(
    mergeRequestAccepterService{d, gitlabClient},
    withMr(d, gitlabClient),
    withPayloadValidation(methodToPayload{http.MethodPost: &AcceptMergeRequestRequest{}}), // Here...
    withMethodCheck(http.MethodPost),
))
```

This caused the struct data to be shared across requests! This was causing issues where payload fields were being shared between API calls. We want new payloads for every API call. 

This MR adjusts the code to add a new factory function on the `methodToPayload` map that creates a new payload per request so that data is not shared across them.

The new pattern is like this:

```go
m.HandleFunc("/mr/merge", middleware(
    mergeRequestAccepterService{d, gitlabClient},
    withMr(d, gitlabClient),
    withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AcceptMergeRequestRequest]}),
    withMethodCheck(http.MethodPost),
))
```

Where `newPayload` creates a new instance of the type provided and returns a pointer to that value in memory.