### PR TITLE
Feat: Automatically open fold under cursor

### DIFF
--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -145,6 +145,7 @@ M.jump = function(file_name, line_number, new_buffer)
     line_number = number_of_lines
   end
   vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+  u.open_fold_under_cursor()
 end
 
 ---Get the data from diffview, such as line information and file name. May be used by

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -146,6 +146,7 @@ M.jump = function(file_name, line_number, new_buffer)
   end
   vim.api.nvim_win_set_cursor(0, { line_number, 0 })
   u.open_fold_under_cursor()
+  vim.cmd("normal! zz")
 end
 
 ---Get the data from diffview, such as line information and file name. May be used by

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -752,4 +752,10 @@ M.get_nested_field = function(table, field)
   end
 end
 
+M.open_fold_under_cursor = function()
+  if vim.fn.foldclosed(vim.fn.line(".")) > -1 then
+    vim.cmd("normal! zo")
+  end
+end
+
 return M


### PR DESCRIPTION
When jumping to the reviewer for a comment on an unchanged line, that line may be in a fold which DiffView closes every time. After jumping to that note a couple of times, this is a little annoying, so in this MR, I have the fold opened automatically.