### PR TITLE
Fix: Publish all drafts

### DIFF
--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -84,7 +84,7 @@ end
 
 ---Publishes all draft notes and comments. Re-renders all discussion views.
 M.confirm_publish_all_drafts = function()
-  local body = {}
+  local body = { publish_all = true }
   job.run_job("/mr/draft_notes/publish", "POST", body, function(data)
     u.notify(data.message, vim.log.levels.INFO)
     state.DRAFT_NOTES = {}

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -100,6 +100,7 @@ M.build = function(override)
     u.notify("Could not install gitlab.nvim!", vim.log.levels.ERROR)
     return false
   end
+  u.notify("Gitlab.nvim installed successfully!", vim.log.levels.INFO)
   return true
 end
 


### PR DESCRIPTION
This fixes an issue where running `require("gitlab").publish_all_drafts()` would result in the error `gitlab.nvim: Could not parse JSON request body: json: cannot unmarshal array into Go value of type app.DraftNotePublishRequest` because of empty `body` in `lua/gitlab/actions/draft_notes/init.lua` line 87.
```lua
M.confirm_publish_all_drafts = function()
  local body = {}
```

Besides, this adds a notification to the user when the server is successfully built.