### PR TITLE
fix: make discussion tree buffers nomodifiable

### DIFF
--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -82,6 +82,7 @@ M.add_empty_titles = function()
           { end_row = linnr - 1, end_col = string.len(v.title), hl_group = "TitleHighlight" }
         )
       end
+      M.switch_can_edit_bufs(false, v.bufnr)
     end
   end
 end


### PR DESCRIPTION
Refreshing the discussion tree made it modifiable because of a missing call of `gitlab.actions.common.switch_can_edit_bufs(false, v.bufnr)`.