### PR TITLE
fix: Incorrect warning about commits

### DIFF
--- a/lua/gitlab/actions/create_mr.lua
+++ b/lua/gitlab/actions/create_mr.lua
@@ -47,7 +47,7 @@ end
 --- continue working on it.
 ---@param args? Mr
 M.start = function(args)
-  if not git.current_branch_up_to_date_on_remote(vim.log.levels.ERROR) then
+  if not git.check_current_branch_up_to_date_on_remote(vim.log.levels.ERROR) then
     return
   end
 

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -82,7 +82,7 @@ M.summary = function()
     vim.api.nvim_set_current_buf(description_popup.bufnr)
   end)
 
-  git.current_branch_up_to_date_on_remote(vim.log.levels.WARN)
+  git.check_current_branch_up_to_date_on_remote(vim.log.levels.WARN)
   git.check_mr_in_good_condition()
 end
 

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -83,6 +83,7 @@ M.summary = function()
   end)
 
   git.current_branch_up_to_date_on_remote(vim.log.levels.WARN)
+  git.check_mr_in_good_condition()
 end
 
 -- Builds a lua list of strings that contain metadata about the current MR. Only builds the

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -150,7 +150,7 @@ end
 ---Returns true if `branch` is up-to-date on remote, otherwise false and warns user
 ---@param log_level integer
 ---@return boolean
-M.current_branch_up_to_date_on_remote = function(log_level)
+M.check_current_branch_up_to_date_on_remote = function(log_level)
   local u = require("gitlab.utils")
 
   -- Get current branch

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -52,6 +52,7 @@ end
 ---Determines whether the tracking branch is ahead of or behind the current branch, and warns the user if so
 ---@param current_branch string
 ---@param remote_branch string
+---@param log_level integer
 ---@return boolean
 M.get_ahead_behind = function(current_branch, remote_branch, log_level)
   local u = require("gitlab.utils")

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -56,7 +56,7 @@ end
 M.get_ahead_behind = function(current_branch, remote_branch, log_level)
   local u = require("gitlab.utils")
   local result, err =
-      run_system({ "git", "rev-list", "--left-right", "--count", current_branch .. "..." .. remote_branch })
+    run_system({ "git", "rev-list", "--left-right", "--count", current_branch .. "..." .. remote_branch })
   if err ~= nil or result == nil then
     u.notify("Could not determine if branch is up-to-date: " .. err, vim.log.levels.ERROR)
     return false
@@ -130,14 +130,14 @@ M.get_all_remote_branches = function()
   local u = require("gitlab.utils")
   local lines = u.lines_into_table(all_branches)
   return List.new(lines)
-      :map(function(line)
-        -- Trim the remote branch
-        return line:match(state.settings.connection_settings.remote .. "/(%S+)")
-      end)
-      :filter(function(branch)
-        -- Don't include the HEAD pointer
-        return not branch:match("^HEAD$")
-      end)
+    :map(function(line)
+      -- Trim the remote branch
+      return line:match(state.settings.connection_settings.remote .. "/(%S+)")
+    end)
+    :filter(function(branch)
+      -- Don't include the HEAD pointer
+      return not branch:match("^HEAD$")
+    end)
 end
 
 ---Return whether something

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -154,16 +154,16 @@ M.current_branch_up_to_date_on_remote = function(log_level)
   local u = require("gitlab.utils")
 
   -- Get current branch
-  local current_branch, err = M.get_current_branch()
-  if err or not current_branch then
-    u.notify("Could not get current branch", vim.log.levels.ERROR)
+  local current_branch, err_current_branch = M.get_current_branch()
+  if err_current_branch or not current_branch then
+    u.notify("Could not get current branch: " .. err_current_branch, vim.log.levels.ERROR)
     return false
   end
 
   -- Get remote tracking branch
-  local remote_branch, err = M.get_remote_branch()
-  if err or not remote_branch then
-    u.notify("Could not get remote branch", vim.log.levels.ERROR)
+  local remote_branch, err_remote_branch = M.get_remote_branch()
+  if err_remote_branch or not remote_branch then
+    u.notify("Could not get remote branch: " .. err_remote_branch, vim.log.levels.ERROR)
     return false
   end
 

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -49,14 +49,14 @@ M.get_remote_branch = function()
   return run_system({ "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}" })
 end
 
----Determines whether there are unpushed commits from local to remote
+---Determines whether the tracking branch is ahead of or behind the current branch, and warns the user if so
 ---@param current_branch string
 ---@param remote_branch string
 ---@return boolean
 M.get_ahead_behind = function(current_branch, remote_branch, log_level)
   local u = require("gitlab.utils")
   local result, err =
-    run_system({ "git", "rev-list", "--left-right", "--count", current_branch .. "..." .. remote_branch })
+      run_system({ "git", "rev-list", "--left-right", "--count", current_branch .. "..." .. remote_branch })
   if err ~= nil or result == nil then
     u.notify("Could not determine if branch is up-to-date: " .. err, vim.log.levels.ERROR)
     return false
@@ -130,14 +130,14 @@ M.get_all_remote_branches = function()
   local u = require("gitlab.utils")
   local lines = u.lines_into_table(all_branches)
   return List.new(lines)
-    :map(function(line)
-      -- Trim the remote branch
-      return line:match(state.settings.connection_settings.remote .. "/(%S+)")
-    end)
-    :filter(function(branch)
-      -- Don't include the HEAD pointer
-      return not branch:match("^HEAD$")
-    end)
+      :map(function(line)
+        -- Trim the remote branch
+        return line:match(state.settings.connection_settings.remote .. "/(%S+)")
+      end)
+      :filter(function(branch)
+        -- Don't include the HEAD pointer
+        return not branch:match("^HEAD$")
+      end)
 end
 
 ---Return whether something

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -73,7 +73,7 @@ M.get_ahead_behind = function(current_branch, remote_branch, log_level)
 
   if ahead > 0 and behind == 0 then
     u.notify(
-      string.format("You have local commits that are not on %s. Have you forgotten to push?", remote_branch),
+      string.format("There are local changes that haven't been pushed to %s yet", remote_branch),
       log_level
     )
     return false

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -52,7 +52,7 @@ end
 ---Determines whether the tracking branch is ahead of or behind the current branch, and warns the user if so
 ---@param current_branch string
 ---@param remote_branch string
----@param log_level integer
+---@param log_level number
 ---@return boolean
 M.get_ahead_behind = function(current_branch, remote_branch, log_level)
   local u = require("gitlab.utils")
@@ -73,10 +73,7 @@ M.get_ahead_behind = function(current_branch, remote_branch, log_level)
   behind = tonumber(behind)
 
   if ahead > 0 and behind == 0 then
-    u.notify(
-      string.format("There are local changes that haven't been pushed to %s yet", remote_branch),
-      log_level
-    )
+    u.notify(string.format("There are local changes that haven't been pushed to %s yet", remote_branch), log_level)
     return false
   end
   if behind > 0 and ahead == 0 then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -62,18 +62,6 @@ M.open = function()
     )
   end
 
-  if state.INFO.has_conflicts then
-    u.notify("This merge request has conflicts!", vim.log.levels.WARN)
-  end
-
-  if state.INFO.state == "closed" then
-    u.notify(string.format("This MR was closed %s", u.time_since(state.INFO.closed_at)), vim.log.levels.WARN)
-  end
-
-  if state.INFO.state == "merged" then
-    u.notify(string.format("This MR was merged %s", u.time_since(state.INFO.merged_at)), vim.log.levels.WARN)
-  end
-
   if state.settings.discussion_diagnostic ~= nil or state.settings.discussion_sign ~= nil then
     u.notify(
       "Diagnostics are now configured as settings.discussion_signs, see :h gitlab.nvim.signs-and-diagnostics",
@@ -99,6 +87,7 @@ M.open = function()
   end
 
   git.current_branch_up_to_date_on_remote(vim.log.levels.WARN)
+  git.check_mr_in_good_condition()
 end
 
 -- Closes the reviewer and cleans up

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -86,7 +86,7 @@ M.open = function()
     require("gitlab").toggle_discussions() -- Fetches data and opens discussions
   end
 
-  git.current_branch_up_to_date_on_remote(vim.log.levels.WARN)
+  git.check_current_branch_up_to_date_on_remote(vim.log.levels.WARN)
   git.check_mr_in_good_condition()
 end
 


### PR DESCRIPTION
This MR updates the function that checks the stability of the branch and MR.

There is now one function responsible for checking whether the current branch is ahead/behind it's tracking branch. That function will warn the user if that's the case for all three possibilites (ahead, behind, or ahead and behind).

The second function is responsible for alerting the user if the status of the current MR is bad: merged, closed, or with conflicts.

These should address the points outlined in the issue outlined by Jakub. For instance, in the complex case where the user is setup to track a remote and they are behind the remote, and the MR associated with that remote has already been closed, they will get both warnings, which is accurate.

Plesae @jakubbortlik give this a look when you have time. Thanks.