### PR TITLE
fix: choose correct MR if multiple are from same source branch

### DIFF
--- a/cmd/app/config.go
+++ b/cmd/app/config.go
@@ -11,7 +11,7 @@ type PluginOptions struct {
 		GitlabRequest  bool `json:"gitlab_request"`
 		GitlabResponse bool `json:"gitlab_response"`
 	} `json:"debug"`
-	ChosenTargetBranch *string `json:"chosen_target_branch,omitempty"`
+	ChosenMrIID        int `json:"chosen_mr_iid"`
 	ConnectionSettings struct {
 		Insecure bool   `json:"insecure"`
 		Remote   string `json:"remote"`

--- a/cmd/app/draft_notes.go
+++ b/cmd/app/draft_notes.go
@@ -90,7 +90,7 @@ func (a draftNoteService) listDraftNotes(w http.ResponseWriter, r *http.Request)
 
 type PostDraftNoteRequest struct {
 	Comment      string `json:"comment" validate:"required"`
-	DiscussionId string `json:"discussion_id,omitempty" validate:"required"`
+	DiscussionId string `json:"discussion_id,omitempty"`
 	PositionData        // TODO: How to add validations to data from external package???
 }
 

--- a/cmd/app/git/git_test.go
+++ b/cmd/app/git/git_test.go
@@ -198,7 +198,7 @@ func TestExtractGitInfo_FailToGetProjectRemoteUrl(t *testing.T) {
 	tC := FailTestCase{
 		desc:        "Error returned by function to get the project remote url",
 		errMsg:      "Some error",
-		expectedErr: "Could not get project Url: Some error",
+		expectedErr: "could not get project Url: Some error",
 	}
 	t.Run(tC.desc, func(t *testing.T) {
 		g := failingUrlManager{
@@ -227,7 +227,7 @@ func TestExtractGitInfo_FailToGetCurrentBranchName(t *testing.T) {
 	tC := FailTestCase{
 		desc:        "Error returned by function to get the project remote url",
 		errMsg:      "Some error",
-		expectedErr: "Failed to get current branch: Some error",
+		expectedErr: "failed to get current branch: Some error",
 	}
 	t.Run(tC.desc, func(t *testing.T) {
 		g := failingBranchManager{

--- a/cmd/app/middleware.go
+++ b/cmd/app/middleware.go
@@ -100,12 +100,17 @@ type withMrMiddleware struct {
 // Gets the current merge request ID and attaches it to the projectInfo
 func (m withMrMiddleware) handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
 		// If the merge request is already attached, skip the middleware logic
 		if m.data.projectInfo.MergeId == 0 {
+
 			options := gitlab.ListProjectMergeRequestsOptions{
 				Scope:        gitlab.Ptr("all"),
 				SourceBranch: &m.data.gitInfo.BranchName,
-				TargetBranch: pluginOptions.ChosenTargetBranch,
+			}
+
+			if pluginOptions.ChosenMrIID != 0 {
+				options.IIDs = gitlab.Ptr([]int{pluginOptions.ChosenMrIID})
 			}
 
 			mergeRequests, _, err := m.client.ListProjectMergeRequests(m.data.projectInfo.ProjectId, &options)

--- a/lua/gitlab/actions/merge_requests.lua
+++ b/lua/gitlab/actions/merge_requests.lua
@@ -38,6 +38,7 @@ M.choose_merge_request = function(opts)
       reviewer.close()
     end
 
+
     vim.schedule(function()
       local _, branch_switch_err = git.switch_branch(choice.source_branch)
       if branch_switch_err ~= nil then
@@ -45,7 +46,7 @@ M.choose_merge_request = function(opts)
       end
 
       vim.schedule(function()
-        state.chosen_target_branch = choice.target_branch
+        state.chosen_mr_iid = choice.iid
         require("gitlab.server").restart(function()
           if opts.open_reviewer then
             require("gitlab").review()

--- a/lua/gitlab/actions/merge_requests.lua
+++ b/lua/gitlab/actions/merge_requests.lua
@@ -38,7 +38,6 @@ M.choose_merge_request = function(opts)
       reviewer.close()
     end
 
-
     vim.schedule(function()
       local _, branch_switch_err = git.switch_branch(choice.source_branch)
       if branch_switch_err ~= nil then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -145,6 +145,8 @@ M.jump = function(file_name, line_number, new_buffer)
     line_number = number_of_lines
   end
   vim.api.nvim_win_set_cursor(0, { line_number, 0 })
+  u.open_fold_under_cursor()
+  vim.cmd("normal! zz")
 end
 
 ---Get the data from diffview, such as line information and file name. May be used by

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -91,7 +91,7 @@ M.build = function(override)
   end
 
   local cmd = u.is_windows() and "cd %s\\cmd && go build -o bin.exe && move bin.exe ..\\"
-      or "cd %s/cmd && go build -o bin && mv bin ../bin"
+    or "cd %s/cmd && go build -o bin && mv bin ../bin"
 
   local command = string.format(cmd, state.settings.bin_path)
   local null = u.is_windows() and " >NUL" or " > /dev/null"

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -20,10 +20,10 @@ M.start = function(callback)
     debug = state.settings.debug,
     log_path = state.settings.log_path,
     connection_settings = state.settings.connection_settings,
-    chosen_target_branch = state.chosen_target_branch,
+    chosen_mr_iid = state.chosen_mr_iid,
   }
 
-  state.chosen_target_branch = nil -- Do not let this interfere with subsequent reviewer.open() calls
+  state.chosen_mr_iid = 0 -- Do not let this interfere with subsequent reviewer.open() calls
 
   local settings = vim.json.encode(go_server_settings)
   local command = string.format("%s '%s'", state.settings.bin, settings)
@@ -91,7 +91,7 @@ M.build = function(override)
   end
 
   local cmd = u.is_windows() and "cd %s\\cmd && go build -o bin.exe && move bin.exe ..\\"
-    or "cd %s/cmd && go build -o bin && mv bin ../bin"
+      or "cd %s/cmd && go build -o bin && mv bin ../bin"
 
   local command = string.format(cmd, state.settings.bin_path)
   local null = u.is_windows() and " >NUL" or " > /dev/null"

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -253,7 +253,7 @@ M.unlinked_discussion_tree = {
 
 -- Used to set a specific target when choosing a merge request, due to the fact
 -- that it's technically possible to have multiple target branches
-M.chosen_target_branch = nil
+M.chosen_mr_iid = 0
 
 -- These keymaps are set globally when the plugin is initialized
 M.set_global_keymaps = function()

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -251,8 +251,7 @@ M.unlinked_discussion_tree = {
   unresolved_expanded = false,
 }
 
--- Used to set a specific target when choosing a merge request, due to the fact
--- that it's technically possible to have multiple target branches
+-- Used to set a specific MR when choosing a merge request
 M.chosen_mr_iid = 0
 
 -- These keymaps are set globally when the plugin is initialized

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -752,4 +752,10 @@ M.get_nested_field = function(table, field)
   end
 end
 
+M.open_fold_under_cursor = function()
+  if vim.fn.foldclosed(vim.fn.line(".")) > -1 then
+    vim.cmd("normal! zo")
+  end
+end
+
 return M

--- a/makefile
+++ b/makefile
@@ -4,10 +4,10 @@ PROJECTNAME=$(shell basename "$(PWD)")
 
 ## compile: build golang project
 compile:
-	@cd cmd && go build -o bin && mv bin ../bin
+	@go build -o bin ./cmd
 ## test: run golang project tests
 test:
-	@cd cmd/app && go test
+	@go test -v ./...
 
 .PHONY: help
 all: help


### PR DESCRIPTION
We'll use the internal ID of the Merge Request rather than the source/target branch when a specific MR is chosen, which is guaranteed to be unique and will avoid situations where we pass along a source/target relationship that is not unique. This is unusual but technically still possible if someone is repeatedly opening MRs against a branch (say main) from another branch, merging them and deleting the source branch, then re-creating a new MR with the same branch.