### PR TITLE
388 cannot choose merge requests

### DIFF
--- a/cmd/app/config.go
+++ b/cmd/app/config.go
@@ -11,7 +11,7 @@ type PluginOptions struct {
 		GitlabRequest  bool `json:"gitlab_request"`
 		GitlabResponse bool `json:"gitlab_response"`
 	} `json:"debug"`
-	ChosenTargetBranch *string `json:"chosen_target_branch,omitempty"`
+	ChosenMrIID        int `json:"chosen_mr_iid"`
 	ConnectionSettings struct {
 		Insecure bool   `json:"insecure"`
 		Remote   string `json:"remote"`

--- a/cmd/app/middleware.go
+++ b/cmd/app/middleware.go
@@ -105,7 +105,10 @@ func (m withMrMiddleware) handle(next http.Handler) http.Handler {
 			options := gitlab.ListProjectMergeRequestsOptions{
 				Scope:        gitlab.Ptr("all"),
 				SourceBranch: &m.data.gitInfo.BranchName,
-				TargetBranch: pluginOptions.ChosenTargetBranch,
+			}
+
+			if pluginOptions.ChosenMrIID != 0 {
+				options.IIDs = gitlab.Ptr([]int{pluginOptions.ChosenMrIID})
 			}
 
 			mergeRequests, _, err := m.client.ListProjectMergeRequests(m.data.projectInfo.ProjectId, &options)

--- a/lua/gitlab/actions/merge_requests.lua
+++ b/lua/gitlab/actions/merge_requests.lua
@@ -45,7 +45,7 @@ M.choose_merge_request = function(opts)
       end
 
       vim.schedule(function()
-        state.chosen_target_branch = choice.target_branch
+        state.chosen_mr_iid = choice.iid
         require("gitlab.server").restart(function()
           if opts.open_reviewer then
             require("gitlab").review()

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -91,7 +91,7 @@ M.build = function(override)
   end
 
   local cmd = u.is_windows() and "cd %s\\cmd && go build -o bin.exe && move bin.exe ..\\"
-      or "cd %s/cmd && go build -o bin && mv bin ../bin"
+    or "cd %s/cmd && go build -o bin && mv bin ../bin"
 
   local command = string.format(cmd, state.settings.bin_path)
   local null = u.is_windows() and " >NUL" or " > /dev/null"

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -20,10 +20,10 @@ M.start = function(callback)
     debug = state.settings.debug,
     log_path = state.settings.log_path,
     connection_settings = state.settings.connection_settings,
-    chosen_target_branch = state.chosen_target_branch,
+    chosen_mr_iid = state.chosen_mr_iid,
   }
 
-  state.chosen_target_branch = nil -- Do not let this interfere with subsequent reviewer.open() calls
+  state.chosen_mr_iid = 0 -- Do not let this interfere with subsequent reviewer.open() calls
 
   local settings = vim.json.encode(go_server_settings)
   local command = string.format("%s '%s'", state.settings.bin, settings)
@@ -91,7 +91,7 @@ M.build = function(override)
   end
 
   local cmd = u.is_windows() and "cd %s\\cmd && go build -o bin.exe && move bin.exe ..\\"
-    or "cd %s/cmd && go build -o bin && mv bin ../bin"
+      or "cd %s/cmd && go build -o bin && mv bin ../bin"
 
   local command = string.format(cmd, state.settings.bin_path)
   local null = u.is_windows() and " >NUL" or " > /dev/null"

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -251,9 +251,8 @@ M.unlinked_discussion_tree = {
   unresolved_expanded = false,
 }
 
--- Used to set a specific target when choosing a merge request, due to the fact
--- that it's technically possible to have multiple target branches
-M.chosen_target_branch = nil
+-- Used to set a specific MR when choosing a merge request
+M.chosen_mr_iid = 0
 
 -- These keymaps are set globally when the plugin is initialized
 M.set_global_keymaps = function()


### PR DESCRIPTION
We'll use the internal ID of the Merge Request rather than the source/target branch when a specific MR is chosen, which is guaranteed to be unique and will avoid situations where we pass along a source/target relationship that is not unique. This is unusual but technically still possible if someone is repeatedly opening MRs against a branch (say main) from another branch, merging them and deleting the source branch, then re-creating a new MR with the same branch.