### PR TITLE
Fix: Restore cursor when updating from outside of tree

### DIFF
--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -63,8 +63,6 @@ local confirm_create_comment = function(text, visual_range, unlinked, discussion
     return
   end
 
-  vim.print("Here: ", unlinked, discussion_id)
-
   local reviewer_data = reviewer.get_reviewer_data()
   if reviewer_data == nil then
     u.notify("Error getting reviewer data", vim.log.levels.ERROR)

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -94,7 +94,7 @@ local confirm_create_comment = function(text, visual_range, unlinked, discussion
     job.run_job("/mr/draft_notes/", "POST", body, function()
       u.notify("Draft reply created!", vim.log.levels.INFO)
       draft_notes.load_draft_notes(function()
-        discussions.rebuild_view(false, true)
+        discussions.rebuild_view(unlinked)
       end)
     end)
     return

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -41,13 +41,7 @@ local confirm_create_comment = function(text, visual_range, unlinked, discussion
     local body = { discussion_id = discussion_id, reply = text, draft = is_draft }
     job.run_job("/mr/reply", "POST", body, function()
       u.notify("Sent reply!", vim.log.levels.INFO)
-      if is_draft then
-        draft_notes.load_draft_notes(function()
-          discussions.rebuild_view(unlinked)
-        end)
-      else
-        discussions.rebuild_view(unlinked)
-      end
+      discussions.rebuild_view(unlinked)
     end)
     return
   end

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -433,7 +433,7 @@ M.rebuild_discussion_tree = function()
     return
   end
 
-  local current_node = discussions_tree.get_node_at_cursor(M.split.winid, M.linked_bufnr, M.discussion_tree)
+  local current_node = discussions_tree.get_node_at_cursor(M.discussion_tree, M.last_node_at_cursor)
 
   local expanded_node_ids = M.gather_expanded_node_ids(M.discussion_tree)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
@@ -472,8 +472,7 @@ M.rebuild_unlinked_discussion_tree = function()
     return
   end
 
-  -- save current node for restoring cursor position
-  local current_node = discussions_tree.get_node_at_cursor(M.split.winid, M.unlinked_bufnr, M.unlinked_discussion_tree)
+  local current_node = discussions_tree.get_node_at_cursor(M.unlinked_discussion_tree, M.last_node_at_cursor)
 
   local expanded_node_ids = M.gather_expanded_node_ids(M.unlinked_discussion_tree)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
@@ -545,6 +544,14 @@ M.create_split_and_bufs = function()
     buffer = linked_bufnr,
     callback = function()
       M.last_row, M.last_column = unpack(vim.api.nvim_win_get_cursor(0))
+      M.last_node_at_cursor = M.discussion_tree and M.discussion_tree:get_node() or nil
+    end,
+  })
+
+  vim.api.nvim_create_autocmd("WinLeave", {
+    buffer = unlinked_bufnr,
+    callback = function()
+      M.last_node_at_cursor = M.unlinked_discussion_tree and M.unlinked_discussion_tree:get_node() or nil
     end,
   })
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -432,6 +432,17 @@ M.rebuild_discussion_tree = function()
   if M.linked_bufnr == nil then
     return
   end
+
+  -- save current node for restoring cursor position
+  local current_node
+  if
+    vim.api.nvim_get_current_win() == M.split.winid
+    and vim.api.nvim_get_current_buf() == M.linked_bufnr
+    and M.discussion_tree ~= nil
+  then
+    current_node = M.discussion_tree:get_node()
+  end
+
   local expanded_node_ids = M.gather_expanded_node_ids(M.discussion_tree)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
 
@@ -447,12 +458,18 @@ M.rebuild_discussion_tree = function()
     bufnr = M.linked_bufnr,
     prepare_node = tree_utils.nui_tree_prepare_node,
   })
+
   -- Re-expand already expanded nodes
   for _, id in ipairs(expanded_node_ids) do
     tree_utils.open_node_by_id(discussion_tree, id)
   end
-
   discussion_tree:render()
+
+  if current_node ~= nil then
+    local root_node = common.get_root_node(M.discussion_tree, current_node)
+    discussions_tree.restore_cursor_position(M.split.winid, discussion_tree, current_node, root_node)
+  end
+
   M.set_tree_keymaps(discussion_tree, M.linked_bufnr, false)
   M.discussion_tree = discussion_tree
   common.switch_can_edit_bufs(false, M.linked_bufnr, M.unlinked_bufnr)
@@ -466,6 +483,17 @@ M.rebuild_unlinked_discussion_tree = function()
   if M.unlinked_bufnr == nil then
     return
   end
+
+  -- save current node for restoring cursor position
+  local current_node
+  if
+    vim.api.nvim_get_current_win() == M.split.winid
+    and vim.api.nvim_get_current_buf() == M.unlinked_bufnr
+    and M.unlinked_discussion_tree ~= nil
+  then
+    current_node = M.unlinked_discussion_tree:get_node()
+  end
+
   local expanded_node_ids = M.gather_expanded_node_ids(M.unlinked_discussion_tree)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
   vim.api.nvim_buf_set_lines(M.unlinked_bufnr, 0, -1, false, {})
@@ -487,6 +515,11 @@ M.rebuild_unlinked_discussion_tree = function()
     tree_utils.open_node_by_id(unlinked_discussion_tree, id)
   end
   unlinked_discussion_tree:render()
+
+  if current_node ~= nil then
+    local root_node = common.get_root_node(M.unlinked_discussion_tree, current_node)
+    discussions_tree.restore_cursor_position(M.split.winid, unlinked_discussion_tree, current_node, root_node)
+  end
 
   M.set_tree_keymaps(unlinked_discussion_tree, M.unlinked_bufnr, true)
   M.unlinked_discussion_tree = unlinked_discussion_tree

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -139,7 +139,7 @@ M.open = function(callback)
   local current_window = vim.api.nvim_get_current_win() -- Save user's current window in case they switched while content was loading
   vim.api.nvim_set_current_win(M.split.winid)
 
-  common.switch_can_edit_bufs(true, M.linked_bufnr, M.unliked_bufnr)
+  common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
   M.rebuild_discussion_tree()
   M.rebuild_unlinked_discussion_tree()
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -433,15 +433,7 @@ M.rebuild_discussion_tree = function()
     return
   end
 
-  -- save current node for restoring cursor position
-  local current_node
-  if
-    vim.api.nvim_get_current_win() == M.split.winid
-    and vim.api.nvim_get_current_buf() == M.linked_bufnr
-    and M.discussion_tree ~= nil
-  then
-    current_node = M.discussion_tree:get_node()
-  end
+  local current_node = discussions_tree.get_node_at_cursor(M.split.winid, M.linked_bufnr, M.discussion_tree)
 
   local expanded_node_ids = M.gather_expanded_node_ids(M.discussion_tree)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
@@ -464,11 +456,7 @@ M.rebuild_discussion_tree = function()
     tree_utils.open_node_by_id(discussion_tree, id)
   end
   discussion_tree:render()
-
-  if current_node ~= nil then
-    local root_node = common.get_root_node(M.discussion_tree, current_node)
-    discussions_tree.restore_cursor_position(M.split.winid, discussion_tree, current_node, root_node)
-  end
+  discussions_tree.restore_cursor_position(M.split.winid, discussion_tree, current_node)
 
   M.set_tree_keymaps(discussion_tree, M.linked_bufnr, false)
   M.discussion_tree = discussion_tree
@@ -485,14 +473,7 @@ M.rebuild_unlinked_discussion_tree = function()
   end
 
   -- save current node for restoring cursor position
-  local current_node
-  if
-    vim.api.nvim_get_current_win() == M.split.winid
-    and vim.api.nvim_get_current_buf() == M.unlinked_bufnr
-    and M.unlinked_discussion_tree ~= nil
-  then
-    current_node = M.unlinked_discussion_tree:get_node()
-  end
+  local current_node = discussions_tree.get_node_at_cursor(M.split.winid, M.unlinked_bufnr, M.unlinked_discussion_tree)
 
   local expanded_node_ids = M.gather_expanded_node_ids(M.unlinked_discussion_tree)
   common.switch_can_edit_bufs(true, M.linked_bufnr, M.unlinked_bufnr)
@@ -515,11 +496,7 @@ M.rebuild_unlinked_discussion_tree = function()
     tree_utils.open_node_by_id(unlinked_discussion_tree, id)
   end
   unlinked_discussion_tree:render()
-
-  if current_node ~= nil then
-    local root_node = common.get_root_node(M.unlinked_discussion_tree, current_node)
-    discussions_tree.restore_cursor_position(M.split.winid, unlinked_discussion_tree, current_node, root_node)
-  end
+  discussions_tree.restore_cursor_position(M.split.winid, unlinked_discussion_tree, current_node)
 
   M.set_tree_keymaps(unlinked_discussion_tree, M.unlinked_bufnr, true)
   M.unlinked_discussion_tree = unlinked_discussion_tree

--- a/lua/gitlab/actions/discussions/tree.lua
+++ b/lua/gitlab/actions/discussions/tree.lua
@@ -423,12 +423,16 @@ M.toggle_nodes = function(winid, tree, unlinked, opts)
 end
 
 -- Get current node for restoring cursor position
----@param winid integer Window number of the discussions split
----@param bufnr integer Buffer number of the current tree
 ---@param tree NuiTree The inline discussion tree or the unlinked discussion tree
-M.get_node_at_cursor = function(winid, bufnr, tree)
-  if vim.api.nvim_get_current_win() == winid and vim.api.nvim_get_current_buf() == bufnr and tree ~= nil then
+---@param last_node NuiTree.Node|nil The last active discussion tree node in case we are not in any of the discussion trees
+M.get_node_at_cursor = function(tree, last_node)
+  if tree == nil then
+    return
+  end
+  if vim.api.nvim_get_current_win() == vim.fn.win_findbuf(tree.bufnr)[1] then
     return tree:get_node()
+  else
+    return last_node
   end
 end
 


### PR DESCRIPTION
This PR improves the user experience in the discussion tree by restoring cursor position after rebuilding the tree. This makes navigation in the discussion tree more fluent without the cursor jumping to the first line of the tree after actions like resolving discussions, adding new comments, publishing drafts etc.