### PR TITLE
Fix: Enable replying if discussion tree is in a different tab

### DIFF
--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -166,7 +166,7 @@ end
 ---@param opts LayoutOpts
 ---@return NuiLayout|nil
 M.create_comment_layout = function(opts)
-  if opts.unlinked ~= true then
+  if opts.unlinked ~= true and opts.discussion_id == nil then
     -- Check that diffview is initialized
     if reviewer.tabnr == nil then
       u.notify("Reviewer must be initialized first", vim.log.levels.ERROR)


### PR DESCRIPTION
This PR fixes the following issue.

The discussion tree can be opened in a tab different than the `Diffview` reviewer tab. This is quite practical if you want to see comments/suggestions next to an *editable* version of the reviewed files. However, replying to comments in such a "detached" discussion tree fails because the `gitlab.actions.comment.create_comment_layout` function verifies that we are in the reviewer tab, and it is also called for `gitlab.actions.discussions.init.reply`, even if the checks are not necessary for a reply.