### PR TITLE
fix: comment creation should not be possible for renamed and moved files

### DIFF
--- a/cmd/app/comment_helpers.go
+++ b/cmd/app/comment_helpers.go
@@ -23,6 +23,7 @@ type LineRange struct {
 /* PositionData represents the position of a comment or note (relative to a file diff) */
 type PositionData struct {
 	FileName       string     `json:"file_name"`
+	OldFileName    string     `json:"old_file_name"`
 	NewLine        *int       `json:"new_line,omitempty"`
 	OldLine        *int       `json:"old_line,omitempty"`
 	HeadCommitSHA  string     `json:"head_commit_sha"`
@@ -41,13 +42,18 @@ type RequestWithPosition interface {
 func buildCommentPosition(commentWithPositionData RequestWithPosition) *gitlab.PositionOptions {
 	positionData := commentWithPositionData.GetPositionData()
 
+	oldFileName := positionData.OldFileName
+	if oldFileName == "" {
+		oldFileName = positionData.FileName
+	}
+
 	opt := &gitlab.PositionOptions{
 		PositionType: &positionData.Type,
 		StartSHA:     &positionData.StartCommitSHA,
 		HeadSHA:      &positionData.HeadCommitSHA,
 		BaseSHA:      &positionData.BaseCommitSHA,
 		NewPath:      &positionData.FileName,
-		OldPath:      &positionData.FileName,
+		OldPath:      &oldFileName,
 		NewLine:      positionData.NewLine,
 		OldLine:      positionData.OldLine,
 	}

--- a/cmd/app/comment_helpers.go
+++ b/cmd/app/comment_helpers.go
@@ -42,6 +42,7 @@ type RequestWithPosition interface {
 func buildCommentPosition(commentWithPositionData RequestWithPosition) *gitlab.PositionOptions {
 	positionData := commentWithPositionData.GetPositionData()
 
+	// If the file has been renamed, then this is a relevant part of the payload
 	oldFileName := positionData.OldFileName
 	if oldFileName == "" {
 		oldFileName = positionData.FileName

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -3,6 +3,7 @@
 --- to this module the data required to make the API calls
 local Popup = require("nui.popup")
 local Layout = require("nui.layout")
+local List = require("gitlab.utils.list")
 local diffview_lib = require("diffview.lib")
 local state = require("gitlab.state")
 local job = require("gitlab.job")
@@ -176,6 +177,15 @@ M.create_comment_layout = function(opts)
     local tabnr = vim.api.nvim_get_current_tabpage()
     if tabnr ~= reviewer.tabnr then
       u.notify("Line location can only be determined within reviewer window", vim.log.levels.ERROR)
+      return
+    end
+
+    -- Check that the file has not been renamed
+    local file_list = view and view.panel and view.panel:ordered_file_list()
+    if file_list and List.new(file_list):includes(function(f)
+          return f.status == "R" and f.active
+        end) then
+      u.notify("Commenting on files that are only moved or renamed is not supported", vim.log.levels.ERROR)
       return
     end
 

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -183,8 +183,8 @@ M.create_comment_layout = function(opts)
     -- Check that the file has not been renamed
     local file_list = view and view.panel and view.panel:ordered_file_list()
     if file_list and List.new(file_list):includes(function(f)
-          return f.status == "R" and f.active
-        end) then
+      return f.status == "R" and f.active
+    end) then
       u.notify("Commenting on files that are only moved or renamed is not supported", vim.log.levels.ERROR)
       return
     end

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -359,6 +359,8 @@ M.create_comment_suggestion = function()
   local layout = M.create_comment_layout({ ranged = range_length > 0, unlinked = false })
   if layout ~= nil then
     layout:mount()
+  else
+    return -- Failure in creating the comment layout
   end
   vim.schedule(function()
     if suggestion_lines then

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -80,6 +80,7 @@ local confirm_create_comment = function(text, visual_range, unlinked, discussion
   local revision = state.MR_REVISIONS[1]
   local position_data = {
     file_name = reviewer_data.file_name,
+    old_file_name = reviewer_data.old_file_name,
     base_commit_sha = revision.base_commit_sha,
     start_commit_sha = revision.start_commit_sha,
     head_commit_sha = revision.head_commit_sha,
@@ -180,8 +181,7 @@ M.create_comment_layout = function(opts)
     end
 
     -- Check that the file has not been renamed
-    local active_file = reviewer.get_current_file_data()
-    if reviewer.is_file_renamed(active_file) and not reviewer.does_file_have_changes(active_file) then
+    if reviewer.is_file_renamed() and not reviewer.does_file_have_changes() then
       u.notify("Commenting on (unchanged) renamed or moved files is not supported", vim.log.levels.ERROR)
       return
     end
@@ -256,7 +256,6 @@ end
 --- This function will open a comment popup in order to create a comment on the changed/updated
 --- line in the current MR
 M.create_comment = function()
-  vim.print("Creating comment...")
   local has_clean_tree, err = git.has_clean_tree()
   if err ~= nil then
     return
@@ -300,7 +299,6 @@ end
 --- This function will open a a popup to create a "note" (e.g. unlinked comment)
 --- on the changed/updated line in the current MR
 M.create_note = function()
-  vim.print("Creating note...")
   local layout = M.create_comment_layout({ ranged = false, unlinked = true })
   if layout ~= nil then
     layout:mount()

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -3,7 +3,6 @@
 --- to this module the data required to make the API calls
 local Popup = require("nui.popup")
 local Layout = require("nui.layout")
-local List = require("gitlab.utils.list")
 local diffview_lib = require("diffview.lib")
 local state = require("gitlab.state")
 local job = require("gitlab.job")
@@ -181,18 +180,9 @@ M.create_comment_layout = function(opts)
     end
 
     -- Check that the file has not been renamed
-    local file_list = view and view.panel and view.panel:ordered_file_list()
-    local active_file = List.new(file_list):find(function(f)
-      return f.active
-    end)
-
-    if
-      active_file
-      and active_file.status == "R"
-      and active_file.stats.additions == 0
-      and active_file.stats.deletions == 0
-    then
-      u.notify("Commenting on files that are only moved or renamed is not supported", vim.log.levels.ERROR)
+    local active_file = reviewer.get_current_file_data()
+    if reviewer.is_file_renamed(active_file) and not reviewer.does_file_have_changes(active_file) then
+      u.notify("Commenting on (unchanged) renamed or moved files is not supported", vim.log.levels.ERROR)
       return
     end
 

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -182,9 +182,16 @@ M.create_comment_layout = function(opts)
 
     -- Check that the file has not been renamed
     local file_list = view and view.panel and view.panel:ordered_file_list()
-    if file_list and List.new(file_list):includes(function(f)
-      return f.status == "R" and f.active
-    end) then
+    local active_file = List.new(file_list):find(function(f)
+      return f.active
+    end)
+
+    if
+      active_file
+      and active_file.status == "R"
+      and active_file.stats.additions == 0
+      and active_file.stats.deletions == 0
+    then
       u.notify("Commenting on files that are only moved or renamed is not supported", vim.log.levels.ERROR)
       return
     end

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -182,7 +182,7 @@ M.create_comment_layout = function(opts)
 
     -- Check that the file has not been renamed
     if reviewer.is_file_renamed() and not reviewer.does_file_have_changes() then
-      u.notify("Commenting on (unchanged) renamed or moved files is not supported", vim.log.levels.ERROR)
+      u.notify("Commenting on (unchanged) renamed or moved files is not supported", vim.log.levels.WARN)
       return
     end
 

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -114,6 +114,7 @@
 ---@class DiffviewInfo
 ---@field modification_type string
 ---@field file_name string
+---@field old_file_name string -- Relevant for renamed files
 ---@field current_bufnr integer
 ---@field new_sha_win_id integer
 ---@field old_sha_win_id integer

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -114,7 +114,8 @@
 ---@class DiffviewInfo
 ---@field modification_type string
 ---@field file_name string
----@field old_file_name string -- Relevant for renamed files
+---Relevant for renamed files only, the name of the file in the previous commit
+---@field old_file_name string
 ---@field current_bufnr integer
 ---@field new_sha_win_id integer
 ---@field old_sha_win_id integer

--- a/lua/gitlab/indicators/common.lua
+++ b/lua/gitlab/indicators/common.lua
@@ -41,7 +41,7 @@ M.filter_placeable_discussions = function()
     draft_notes = {}
   end
 
-  local file = reviewer.get_current_file()
+  local file = reviewer.get_current_file_path()
   if not file then
     return {}
   end

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -163,7 +163,7 @@ M.get_reviewer_data = function()
 
   local is_current_sha_focused = M.is_current_sha_focused()
 
-  local modification_type = hunks.get_modification_type(old_line, new_line, current_file, is_current_sha_focused)
+  local modification_type = hunks.get_modification_type(old_line, new_line, is_current_sha_focused)
   if modification_type == nil then
     u.notify("Error getting modification type", vim.log.levels.ERROR)
     return
@@ -180,6 +180,7 @@ M.get_reviewer_data = function()
 
   return {
     file_name = layout.a.file.path,
+    old_file_name = M.is_file_renamed() and layout.b.file.path or "",
     old_line_from_buf = old_line,
     new_line_from_buf = new_line,
     modification_type = modification_type,
@@ -205,29 +206,37 @@ M.is_current_sha_focused = function()
   return current_win == b_win
 end
 
----Get currently shown file
----@return string|nil
-M.get_current_file_path = function()
-  local view = diffview_lib.get_current_view()
-  if not view or not view.panel or not view.panel.cur_file then
-    return
-  end
-  return view.panel.cur_file.path
-end
-
+---Get currently shown file data
 M.get_current_file_data = function()
   local view = diffview_lib.get_current_view()
-  local file_list = view and view.panel and view.panel:ordered_file_list()
-  return List.new(file_list):find(function(f)
-    return f.active
-  end)
+  return view and view.panel and view.panel.cur_file
 end
 
-M.is_file_renamed = function(file_data)
-  return file_data.status == "R"
+---Get currently shown file path
+---@return string|nil
+M.get_current_file_path = function()
+  local file_data = M.get_current_file_data()
+  return file_data and file_data.path
 end
 
-M.does_file_have_changes = function(file_data)
+---Get currently shown file's old path
+---@return string|nil
+M.get_current_file_oldpath = function()
+  local file_data = M.get_current_file_data()
+  return file_data and file_data.oldpath
+end
+
+---Tell whether current file is renamed or not
+---@return boolean|nil
+M.is_file_renamed = function()
+  local file_data = M.get_current_file_data()
+  return file_data and file_data.status == "R"
+end
+
+---Tell whether current file has changes or not
+---@return boolean|nil
+M.does_file_have_changes = function()
+  local file_data = M.get_current_file_data()
   return file_data.stats.additions > 0 or file_data.stats.deletions > 0
 end
 

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -152,7 +152,7 @@ M.get_reviewer_data = function()
     return
   end
 
-  local current_file = M.get_current_file()
+  local current_file = M.get_current_file_path()
   if current_file == nil then
     u.notify("Error getting current file from Diffview", vim.log.levels.ERROR)
     return
@@ -207,12 +207,28 @@ end
 
 ---Get currently shown file
 ---@return string|nil
-M.get_current_file = function()
+M.get_current_file_path = function()
   local view = diffview_lib.get_current_view()
   if not view or not view.panel or not view.panel.cur_file then
     return
   end
   return view.panel.cur_file.path
+end
+
+M.get_current_file_data = function()
+  local view = diffview_lib.get_current_view()
+  local file_list = view and view.panel and view.panel:ordered_file_list()
+  return List.new(file_list):find(function(f)
+    return f.active
+  end)
+end
+
+M.is_file_renamed = function(file_data)
+  return file_data.status == "R"
+end
+
+M.does_file_have_changes = function(file_data)
+  return file_data.stats.additions > 0 or file_data.stats.deletions > 0
 end
 
 ---Diffview exposes events which can be used to setup autocommands.

--- a/lua/gitlab/reviewer/location.lua
+++ b/lua/gitlab/reviewer/location.lua
@@ -47,16 +47,6 @@ function Location:build_location_data()
     line_range = nil,
   }
 
-  -- If the file has been renamed, we need to include the old file path as well
-  -- local is_renamed = false
-  -- local view = diffview_lib.get_current_view()
-  -- local active_file = reviewer.get_active_file()
-  -- if active_file and active_file.status == "R" then
-  --   is_renamed = true
-  -- end
-  --
-  -- vim.print("IS RENAMED", is_renamed)
-
   -- Comment on new line: Include only new_line in payload.
   -- Comment on deleted line: Include only old_line in payload.
   -- The line was not found in any hunks, send both lines.
@@ -106,7 +96,13 @@ function Location:get_line_number_from_new_sha(line)
     return line
   end
   -- Otherwise we want to get the matching line in the opposite buffer
-  return hunks.calculate_matching_line_new(self.base_sha, self.head_sha, self.reviewer_data.file_name, line)
+  return hunks.calculate_matching_line_new(
+    self.base_sha,
+    self.head_sha,
+    self.reviewer_data.file_name,
+    self.reviewer_data.old_file_name,
+    line
+  )
 end
 
 -- Returns the matching line from the old SHA.
@@ -122,7 +118,13 @@ function Location:get_line_number_from_old_sha(line)
   end
 
   -- Otherwise we want to get the matching line in the opposite buffer
-  return hunks.calculate_matching_line_new(self.head_sha, self.base_sha, self.reviewer_data.file_name, line)
+  return hunks.calculate_matching_line_new(
+    self.head_sha,
+    self.base_sha,
+    self.reviewer_data.file_name,
+    self.reviewer_data.old_file_name,
+    line
+  )
 end
 
 -- Returns the current line number from whatever SHA (new or old)
@@ -175,7 +177,7 @@ function Location:set_start_range(visual_range)
     return
   end
 
-  local modification_type = hunks.get_modification_type(old_line, new_line, current_file, is_current_sha_focused)
+  local modification_type = hunks.get_modification_type(old_line, new_line, is_current_sha_focused)
   if modification_type == nil then
     u.notify("Error getting modification type for start of range", vim.log.levels.ERROR)
     return
@@ -217,7 +219,7 @@ function Location:set_end_range(visual_range)
 
   local reviewer = require("gitlab.reviewer")
   local is_current_sha_focused = reviewer.is_current_sha_focused()
-  local modification_type = hunks.get_modification_type(old_line, new_line, current_file, is_current_sha_focused)
+  local modification_type = hunks.get_modification_type(old_line, new_line, is_current_sha_focused)
   if modification_type == nil then
     u.notify("Error getting modification type for end of range", vim.log.levels.ERROR)
     return

--- a/lua/gitlab/reviewer/location.lua
+++ b/lua/gitlab/reviewer/location.lua
@@ -47,6 +47,16 @@ function Location:build_location_data()
     line_range = nil,
   }
 
+  -- If the file has been renamed, we need to include the old file path as well
+  -- local is_renamed = false
+  -- local view = diffview_lib.get_current_view()
+  -- local active_file = reviewer.get_active_file()
+  -- if active_file and active_file.status == "R" then
+  --   is_renamed = true
+  -- end
+  --
+  -- vim.print("IS RENAMED", is_renamed)
+
   -- Comment on new line: Include only new_line in payload.
   -- Comment on deleted line: Include only old_line in payload.
   -- The line was not found in any hunks, send both lines.
@@ -135,7 +145,7 @@ end
 ---@param visual_range LineRange
 ---@return ReviewerLineInfo|nil
 function Location:set_start_range(visual_range)
-  local current_file = require("gitlab.reviewer").get_current_file()
+  local current_file = require("gitlab.reviewer").get_current_file_path()
   if current_file == nil then
     u.notify("Error getting current file from Diffview", vim.log.levels.ERROR)
     return
@@ -182,7 +192,7 @@ end
 -- for the Gitlab payload
 ---@param visual_range LineRange
 function Location:set_end_range(visual_range)
-  local current_file = require("gitlab.reviewer").get_current_file()
+  local current_file = require("gitlab.reviewer").get_current_file_path()
   if current_file == nil then
     u.notify("Error getting current file from Diffview", vim.log.levels.ERROR)
     return


### PR DESCRIPTION
Makes it not possible to leave comments on renamed files