### PR TITLE
Fix: Show non-resolvable notes in winbar

### DIFF
--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -55,7 +55,8 @@ local get_data = function(nodes)
 end
 
 local function content()
-  local resolvable_discussions, resolved_discussions, non_resolvable_discussions = get_data(state.DISCUSSION_DATA.discussions)
+  local resolvable_discussions, resolved_discussions, non_resolvable_discussions =
+    get_data(state.DISCUSSION_DATA.discussions)
   local resolvable_notes, resolved_notes, non_resolvable_notes = get_data(state.DISCUSSION_DATA.unlinked_discussions)
 
   local draft_notes = require("gitlab.actions.draft_notes")
@@ -116,7 +117,13 @@ end
 ---@param resolved_count integer
 ---@param drafts_count integer
 ---@return string
-local add_drafts_and_resolvable = function(base_title, resolvable_count, resolved_count, drafts_count, non_resolvable_count)
+local add_drafts_and_resolvable = function(
+  base_title,
+  resolvable_count,
+  resolved_count,
+  drafts_count,
+  non_resolvable_count
+)
   if resolvable_count == 0 and drafts_count == 0 and non_resolvable_count == 0 then
     return base_title
   end
@@ -125,7 +132,9 @@ local add_drafts_and_resolvable = function(base_title, resolvable_count, resolve
     base_title = base_title .. u.pluralize(non_resolvable_count, "comment")
   end
   if resolvable_count ~= 0 then
-    base_title = base_title .. get_connector(base_title) .. string.format("%d/%s", resolved_count, u.pluralize(resolvable_count, "thread"))
+    base_title = base_title
+      .. get_connector(base_title)
+      .. string.format("%d/%s", resolved_count, u.pluralize(resolvable_count, "thread"))
   end
   if drafts_count ~= 0 then
     base_title = base_title .. get_connector(base_title) .. u.pluralize(drafts_count, "draft")
@@ -136,9 +145,20 @@ end
 
 ---@param t WinbarTable
 M.make_winbar = function(t)
-  local discussion_title =
-    add_drafts_and_resolvable("Inline Comments", t.resolvable_discussions, t.resolved_discussions, t.inline_draft_notes, t.non_resolvable_discussions)
-  local notes_title = add_drafts_and_resolvable("Notes", t.resolvable_notes, t.resolved_notes, t.unlinked_draft_notes, t.non_resolvable_notes)
+  local discussion_title = add_drafts_and_resolvable(
+    "Inline Comments",
+    t.resolvable_discussions,
+    t.resolved_discussions,
+    t.inline_draft_notes,
+    t.non_resolvable_discussions
+  )
+  local notes_title = add_drafts_and_resolvable(
+    "Notes",
+    t.resolvable_notes,
+    t.resolved_notes,
+    t.unlinked_draft_notes,
+    t.non_resolvable_notes
+  )
 
   -- Colorize the active tab
   if M.current_view_type == "discussions" then

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -1,3 +1,4 @@
+local u = require("gitlab.utils")
 local List = require("gitlab.utils.list")
 local state = require("gitlab.state")
 
@@ -17,17 +18,26 @@ M.set_buffers = function(linked_bufnr, unlinked_bufnr)
 end
 
 ---@param nodes Discussion[]|UnlinkedDiscussion[]|nil
----@return number, number
+---@return number, number, number
 local get_data = function(nodes)
   local total_resolvable = 0
   local total_resolved = 0
+  local total_non_resolvable = 0
   if nodes == nil or nodes == vim.NIL then
-    return total_resolvable, total_resolved
+    return total_resolvable, total_resolved, total_non_resolvable
   end
 
   total_resolvable = List.new(nodes):reduce(function(agg, d)
     local first_child = d.notes[1]
     if first_child and first_child.resolvable then
+      agg = agg + 1
+    end
+    return agg
+  end, 0)
+
+  total_non_resolvable = List.new(nodes):reduce(function(agg, d)
+    local first_child = d.notes[1]
+    if first_child and not first_child.resolvable then
       agg = agg + 1
     end
     return agg
@@ -41,12 +51,12 @@ local get_data = function(nodes)
     return agg
   end, 0)
 
-  return total_resolvable, total_resolved
+  return total_resolvable, total_resolved, total_non_resolvable
 end
 
 local function content()
-  local resolvable_discussions, resolved_discussions = get_data(state.DISCUSSION_DATA.discussions)
-  local resolvable_notes, resolved_notes = get_data(state.DISCUSSION_DATA.unlinked_discussions)
+  local resolvable_discussions, resolved_discussions, non_resolvable_discussions = get_data(state.DISCUSSION_DATA.discussions)
+  local resolvable_notes, resolved_notes, non_resolvable_notes = get_data(state.DISCUSSION_DATA.unlinked_discussions)
 
   local draft_notes = require("gitlab.actions.draft_notes")
   local inline_draft_notes, unlinked_draft_notes = List.new(state.DRAFT_NOTES):partition(function(note)
@@ -64,10 +74,12 @@ local function content()
   local t = {
     resolvable_discussions = resolvable_discussions,
     resolved_discussions = resolved_discussions,
+    non_resolvable_discussions = non_resolvable_discussions,
     inline_draft_notes = #inline_draft_notes,
     unlinked_draft_notes = #unlinked_draft_notes,
     resolvable_notes = resolvable_notes,
     resolved_notes = resolved_notes,
+    non_resolvable_notes = non_resolvable_notes,
     help_keymap = state.settings.keymaps.help,
   }
 
@@ -94,34 +106,39 @@ M.update_winbar = function()
   vim.api.nvim_set_option_value("winbar", c, { scope = "local", win = win_id })
 end
 
+local function get_connector(base_title)
+  return string.match(base_title, "%($") and "" or "; "
+end
+
 ---Builds the title string for both sections, using the count of resolvable and draft nodes
 ---@param base_title string
 ---@param resolvable_count integer
 ---@param resolved_count integer
 ---@param drafts_count integer
 ---@return string
-local add_drafts_and_resolvable = function(base_title, resolvable_count, resolved_count, drafts_count)
+local add_drafts_and_resolvable = function(base_title, resolvable_count, resolved_count, drafts_count, non_resolvable_count)
+  if resolvable_count == 0 and drafts_count == 0 and non_resolvable_count == 0 then
+    return base_title
+  end
+  base_title = base_title .. " ("
+  if non_resolvable_count ~= 0 then
+    base_title = base_title .. u.pluralize(non_resolvable_count, "comment")
+  end
   if resolvable_count ~= 0 then
-    base_title = base_title .. string.format(" (%d/%d resolved", resolvable_count, resolved_count)
+    base_title = base_title .. get_connector(base_title) .. string.format("%d/%s", resolved_count, u.pluralize(resolvable_count, "thread"))
   end
   if drafts_count ~= 0 then
-    if resolvable_count ~= 0 then
-      base_title = base_title .. string.format("; %d drafts)", drafts_count)
-    else
-      base_title = base_title .. string.format(" (%d drafts)", drafts_count)
-    end
-  elseif resolvable_count ~= 0 then
-    base_title = base_title .. ")"
+    base_title = base_title .. get_connector(base_title) .. u.pluralize(drafts_count, "draft")
   end
-
+  base_title = base_title .. ")"
   return base_title
 end
 
 ---@param t WinbarTable
 M.make_winbar = function(t)
   local discussion_title =
-    add_drafts_and_resolvable("Inline Comments", t.resolvable_discussions, t.resolved_discussions, t.inline_draft_notes)
-  local notes_title = add_drafts_and_resolvable("Notes", t.resolvable_notes, t.resolved_notes, t.unlinked_draft_notes)
+    add_drafts_and_resolvable("Inline Comments", t.resolvable_discussions, t.resolved_discussions, t.inline_draft_notes, t.non_resolvable_discussions)
+  local notes_title = add_drafts_and_resolvable("Notes", t.resolvable_notes, t.resolved_notes, t.unlinked_draft_notes, t.non_resolvable_notes)
 
   -- Colorize the active tab
   if M.current_view_type == "discussions" then

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -85,10 +85,12 @@
 ---@field view_type string
 ---@field resolvable_discussions number
 ---@field resolved_discussions number
+---@field non_resolvable_discussions number
 ---@field inline_draft_notes number
 ---@field unlinked_draft_notes number
 ---@field resolvable_notes number
 ---@field resolved_notes number
+---@field non_resolvable_notes number
 ---@field help_keymap string
 ---
 ---@class SignTable

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -98,7 +98,7 @@ end
 ---@param num integer The count of the item/word
 ---@param word string The word to pluralize
 ---@return string
-local function pluralize(num, word)
+M.pluralize = function(num, word)
   return num .. string.format(" %s", word) .. ((num > 1 or num <= 0) and "s" or "")
 end
 
@@ -122,13 +122,13 @@ M.time_since = function(date_string, current_date_table)
   local time_diff = current_date - date
 
   if time_diff < 60 then
-    return pluralize(time_diff, "second") .. " ago"
+    return M.pluralize(time_diff, "second") .. " ago"
   elseif time_diff < 3600 then
-    return pluralize(math.floor(time_diff / 60), "minute") .. " ago"
+    return M.pluralize(math.floor(time_diff / 60), "minute") .. " ago"
   elseif time_diff < 86400 then
-    return pluralize(math.floor(time_diff / 3600), "hour") .. " ago"
+    return M.pluralize(math.floor(time_diff / 3600), "hour") .. " ago"
   elseif time_diff < 2592000 then
-    return pluralize(math.floor(time_diff / 86400), "day") .. " ago"
+    return M.pluralize(math.floor(time_diff / 86400), "day") .. " ago"
   else
     local formatted_date = os.date("%B %e, %Y", date)
     return tostring(formatted_date)
@@ -457,13 +457,13 @@ M.format_date = function(date_string)
   local time_diff = current_date - date
 
   if time_diff < 60 then
-    return pluralize(time_diff, "second")
+    return M.pluralize(time_diff, "second")
   elseif time_diff < 3600 then
-    return pluralize(math.floor(time_diff / 60), "minute")
+    return M.pluralize(math.floor(time_diff / 60), "minute")
   elseif time_diff < 86400 then
-    return pluralize(math.floor(time_diff / 3600), "hour")
+    return M.pluralize(math.floor(time_diff / 3600), "hour")
   elseif time_diff < 2592000 then
-    return pluralize(math.floor(time_diff / 86400), "day")
+    return M.pluralize(math.floor(time_diff / 86400), "day")
   else
     local formatted_date = os.date("%A, %B %e", date)
     return formatted_date


### PR DESCRIPTION
This PR closes #411 by implementing the following:
- non-resolvable notes are added to the winbar as `comments` (this is done for inline comments too, even though I don't think there can be any non-resolvable inline comments, however, it makes the code a little cleaner (no need for checking some `nil` values) and it makes it safer in the strange case that there actually would be a non-resolvable inline discussion).
- `resolved` is changed to `threads`
- the order in showing threads is changed from `total/resolved` to `resolved/total`
- the words, `comments, threads, drafts` are used in the correct number if there's just 1 of them 