### PR TITLE
Feat: Automatically update MR summary details

### DIFF
--- a/lua/gitlab/actions/approvals.lua
+++ b/lua/gitlab/actions/approvals.lua
@@ -1,13 +1,26 @@
 local job = require("gitlab.job")
+local state = require("gitlab.state")
+local u = require("gitlab.utils")
 
 local M = {}
 
+local refresh_status_state = function(data)
+  u.notify(data.message, vim.log.levels.INFO)
+  state.load_new_state("info", function()
+    require("gitlab.actions.summary").update_summary_details()
+  end)
+end
+
 M.approve = function()
-  job.run_job("/mr/approve", "POST")
+  job.run_job("/mr/approve", "POST", nil, function(data)
+    refresh_status_state(data)
+  end)
 end
 
 M.revoke = function()
-  job.run_job("/mr/revoke", "POST")
+  job.run_job("/mr/revoke", "POST", nil, function(data)
+    refresh_status_state(data)
+  end)
 end
 
 return M

--- a/lua/gitlab/actions/assignees_and_reviewers.lua
+++ b/lua/gitlab/actions/assignees_and_reviewers.lua
@@ -22,6 +22,12 @@ M.delete_reviewer = function()
   M.delete_popup("reviewer")
 end
 
+local refresh_user_state = function(type, data, message)
+  u.notify(message, vim.log.levels.INFO)
+  state.INFO[type] = data
+  require("gitlab.actions.summary").update_summary_details()
+end
+
 M.add_popup = function(type)
   local plural = type .. "s"
   local current = state.INFO[plural]
@@ -39,8 +45,7 @@ M.add_popup = function(type)
     table.insert(current_ids, choice.id)
     local body = { ids = current_ids }
     job.run_job("/mr/" .. type, "PUT", body, function(data)
-      u.notify(data.message, vim.log.levels.INFO)
-      state.INFO[plural] = data[plural]
+      refresh_user_state(plural, data[plural], data.message)
     end)
   end)
 end
@@ -61,7 +66,7 @@ M.delete_popup = function(type)
     local body = { ids = ids }
     job.run_job("/mr/" .. type, "PUT", body, function(data)
       u.notify(data.message, vim.log.levels.INFO)
-      state.INFO[plural] = data[plural]
+      refresh_user_state(plural, data[plural], data.message)
     end)
   end)
 end

--- a/lua/gitlab/actions/labels.lua
+++ b/lua/gitlab/actions/labels.lua
@@ -14,8 +14,10 @@ M.delete_label = function()
   M.delete_popup("label")
 end
 
-local refresh_label_state = function(labels)
+local refresh_label_state = function(labels, message)
+  u.notify(message, vim.log.levels.INFO)
   state.INFO.labels = labels
+  require("gitlab.actions.summary").update_summary_details()
 end
 
 local get_current_labels = function()
@@ -41,9 +43,7 @@ M.add_popup = function(type)
     table.insert(current_labels, choice)
     local body = { labels = current_labels }
     job.run_job("/mr/" .. type, "PUT", body, function(data)
-      u.notify(data.message, vim.log.levels.INFO)
-
-      refresh_label_state(data.labels)
+      refresh_label_state(data.labels, data.message)
     end)
   end)
 end
@@ -59,8 +59,7 @@ M.delete_popup = function(type)
     local filtered_labels = u.filter(current_labels, choice)
     local body = { labels = filtered_labels }
     job.run_job("/mr/" .. type, "PUT", body, function(data)
-      u.notify(data.message, vim.log.levels.INFO)
-      refresh_label_state(data.labels)
+      refresh_label_state(data.labels, data.message)
     end)
   end)
 end

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -184,7 +184,7 @@ M.create_layout = function(info_lines)
         Layout.Box({
           Layout.Box(details_popup, { size = longest_line + 3 }),
           Layout.Box(description_popup, { grow = 1 }),
-        }, { dir = "row", size = "100%" }),
+        }, { dir = "row", size = "95%" }),
       }, { dir = "col" })
     else
       internal_layout = Layout.Box({

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -97,7 +97,7 @@ M.update_summary_details = function()
   end
   local details_lines = state.settings.info.enabled and M.build_info_lines() or { "" }
   local internal_layout = M.create_internal_layout(details_lines, M.title_popup, M.description_popup, M.info_popup)
-  M.layout:update(M.get_outer_layout(), internal_layout)
+  M.layout:update(M.get_outer_layout_config(), internal_layout)
   M.update_details_popup(M.info_popup.bufnr, details_lines)
 end
 
@@ -200,7 +200,7 @@ M.create_layout = function(info_lines)
 
   local internal_layout = M.create_internal_layout(info_lines, title_popup, description_popup, details_popup)
 
-  local layout = Layout(M.get_outer_layout(), internal_layout)
+  local layout = Layout(M.get_outer_layout_config(), internal_layout)
 
   popup.set_up_autocommands(description_popup, layout, vim.api.nvim_get_current_win())
 
@@ -235,7 +235,7 @@ M.create_internal_layout = function(info_lines, title_popup, description_popup, 
   return internal_layout
 end
 
-M.get_outer_layout = function()
+M.get_outer_layout_config = function()
   local settings = u.merge(state.settings.popup, state.settings.popup.summary or {})
   return {
     position = settings.position,

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -237,7 +237,7 @@ end
 
 M.get_outer_layout = function()
   local settings = u.merge(state.settings.popup, state.settings.popup.summary or {})
-  {
+  return {
     position = settings.position,
     relative = "editor",
     size = {

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -187,6 +187,8 @@ M.edit_summary = function()
   end)
 end
 
+---Create the Summary layout and individual popups that make up the Layout.
+---@return NuiLayout, NuiPopup, NuiPopup, NuiPopup
 M.create_layout = function(info_lines)
   local settings = u.merge(state.settings.popup, state.settings.popup.summary or {})
   local title_popup = Popup(popup.create_box_popup_state(nil, false, settings))
@@ -207,6 +209,12 @@ M.create_layout = function(info_lines)
   return layout, title_popup, description_popup, details_popup
 end
 
+---Create the internal layout of the Summary and individual popups that make up the Layout.
+---@param info_lines string[] Table of strings that make up the details content
+---@param title_popup NuiPopup
+---@param description_popup NuiPopup
+---@param details_popup NuiPopup
+---@return NuiLayout.Box
 M.create_internal_layout = function(info_lines, title_popup, description_popup, details_popup)
   local internal_layout
   if state.settings.info.enabled then
@@ -235,6 +243,8 @@ M.create_internal_layout = function(info_lines, title_popup, description_popup, 
   return internal_layout
 end
 
+---Create the config for the outer Layout of the Summary
+---@return nui_layout_options
 M.get_outer_layout_config = function()
   local settings = u.merge(state.settings.popup, state.settings.popup.summary or {})
   return {


### PR DESCRIPTION
Hi @harrisoncramer, this is an implementation of #401. I've marked it as a draft because it will need some reworking if #426 is merged in. I'd be grateful if you could review it and consider including it in the plugin.

With this PR, when the Summary popup is open the following items in the Details are updated automatically when the user runs a command that changes the MR state:
- Updated
- Status
- Assignees
- Reviewers
- Labels