### PR TITLE
Feat: Show update progress in winbar

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -253,6 +253,7 @@ you call this function with no values the defaults will be used:
           collapsed = " ",  -- Icon for collapsed discussion thread
           indentation = "  ", -- Indentation Icon
         },
+        spinner_chars = { "/", "|", "\\", "-" }, -- Characters for the refresh animation
         auto_open = true, -- Automatically open when the reviewer is opened
         default_view = "discussions" -- Show "discussions" or "notes" by default
         blacklist = {}, -- List of usernames to remove from tree (bots, CI, etc)

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -55,6 +55,7 @@ end
 ---Makes API call to get the discussion data, stores it in the state, and calls the callback
 ---@param callback function|nil
 M.load_discussions = function(callback)
+  state.discussion_tree.last_updated = nil
   state.load_new_state("discussion_data", function(data)
     if not state.DISCUSSION_DATA then
       state.DISCUSSION_DATA = {}
@@ -108,6 +109,7 @@ M.refresh_diagnostics_and_winbar = function()
   end
   winbar.update_winbar()
   common.add_empty_titles()
+  state.discussion_tree.last_updated = os.time()
 end
 
 ---Opens the discussion tree, sets the keybindings. It also
@@ -603,7 +605,6 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
 
   if keymaps.discussion_tree.refresh_data then
     vim.keymap.set("n", keymaps.discussion_tree.refresh_data, function()
-      u.notify("Refreshing data...", vim.log.levels.INFO)
       draft_notes.rebuild_view(unlinked, false)
     end, {
       buffer = bufnr,

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -48,7 +48,7 @@ M.rebuild_view = function(unlinked, all)
     else
       M.rebuild_discussion_tree()
     end
-    M.refresh_diagnostics_and_winbar()
+    M.refresh_diagnostics()
   end)
 end
 
@@ -73,7 +73,7 @@ end
 M.initialize_discussions = function()
   signs.setup_signs()
   reviewer.set_callback_for_file_changed(function()
-    M.refresh_diagnostics_and_winbar()
+    M.refresh_diagnostics()
     M.modifiable(false)
     reviewer.set_reviewer_keymaps()
   end)
@@ -103,11 +103,10 @@ M.modifiable = function(bool)
 end
 
 --- Take existing data and refresh the diagnostics, the winbar, and the signs
-M.refresh_diagnostics_and_winbar = function()
+M.refresh_diagnostics = function()
   if state.settings.discussion_signs.enabled then
     diagnostics.refresh_diagnostics()
   end
-  winbar.update_winbar()
   common.add_empty_titles()
   state.discussion_tree.last_updated = os.time()
 end
@@ -156,7 +155,7 @@ M.open = function(callback)
   end
 
   vim.schedule(function()
-    M.refresh_diagnostics_and_winbar()
+    M.refresh_diagnostics()
   end)
 end
 
@@ -587,7 +586,7 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
     if keymaps.discussion_tree.jump_to_reviewer then
       vim.keymap.set("n", keymaps.discussion_tree.jump_to_reviewer, function()
         if M.is_current_node_note(tree) then
-          common.jump_to_reviewer(tree, M.refresh_diagnostics_and_winbar)
+          common.jump_to_reviewer(tree, M.refresh_diagnostics)
         end
       end, { buffer = bufnr, desc = "Jump to reviewer", nowait = keymaps.discussion_tree.jump_to_reviewer_nowait })
     end
@@ -803,7 +802,6 @@ end
 ---Toggle between draft mode (comments posted as drafts) and live mode (comments are posted immediately)
 M.toggle_draft_mode = function()
   state.settings.discussion_tree.draft_mode = not state.settings.discussion_tree.draft_mode
-  winbar.update_winbar()
 end
 
 ---Toggle between sorting by "original comment" (oldest at the top) or "latest reply" (newest at the

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -48,6 +48,7 @@ M.rebuild_view = function(unlinked, all)
     else
       M.rebuild_discussion_tree()
     end
+    state.discussion_tree.last_updated = os.time()
     M.refresh_diagnostics()
   end)
 end
@@ -71,6 +72,7 @@ end
 
 ---Initialize everything for discussions like setup of signs, callbacks for reviewer, etc.
 M.initialize_discussions = function()
+  state.discussion_tree.last_updated = os.time()
   signs.setup_signs()
   reviewer.set_callback_for_file_changed(function()
     M.refresh_diagnostics()
@@ -108,7 +110,6 @@ M.refresh_diagnostics = function()
     diagnostics.refresh_diagnostics()
   end
   common.add_empty_titles()
-  state.discussion_tree.last_updated = os.time()
 end
 
 ---Opens the discussion tree, sets the keybindings. It also

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -25,6 +25,7 @@ end
 ---Makes API call to get the discussion data, stores it in the state, and calls the callback
 ---@param callback function|nil
 M.load_draft_notes = function(callback)
+  state.discussion_tree.last_updated = nil
   state.load_new_state("draft_notes", function()
     if callback ~= nil then
       callback()

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -92,6 +92,7 @@
 ---@field resolved_notes number
 ---@field non_resolvable_notes number
 ---@field help_keymap string
+---@field updated string
 ---
 ---@class SignTable
 ---@field name string

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -96,7 +96,6 @@ return {
   publish_all_drafts = draft_notes.publish_all_drafts,
   refresh_data = function()
     -- This also rebuilds the regular views
-    u.notify("Refreshing data...", vim.log.levels.INFO)
     draft_notes.rebuild_view(false, true)
   end,
   -- Other functions 🤷

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -151,6 +151,7 @@ M.settings = {
       collapsed = " ",
       indentation = "  ",
     },
+    spinner_chars = { "-", "\\", "|", "/" },
     auto_open = true,
     default_view = "discussions",
     blacklist = {},

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -122,7 +122,7 @@ M.time_since = function(date_string, current_date_table)
   local time_diff = current_date - date
 
   if time_diff < 60 then
-    return "moments ago"
+    return "just now"
   elseif time_diff < 3600 then
     return M.pluralize(math.floor(time_diff / 60), "minute") .. " ago"
   elseif time_diff < 86400 then

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -122,7 +122,7 @@ M.time_since = function(date_string, current_date_table)
   local time_diff = current_date - date
 
   if time_diff < 60 then
-    return M.pluralize(time_diff, "second") .. " ago"
+    return "moments ago"
   elseif time_diff < 3600 then
     return M.pluralize(math.floor(time_diff / 60), "minute") .. " ago"
   elseif time_diff < 86400 then


### PR DESCRIPTION
Hi @harrisoncramer, this is an attempt to implement #409.

With this PR, the winbar shows the time since the last update of the discussion data and it shows a simple animation when the data is being reloaded.

There are some shortcomings that would require some more work to solve:
1. The winbar has become quite crammed when using position `left` or `right` for the discussion tree, so that the "Inline Comments" section can easily move outside of the window. To fix this, we'd have to add some more elaborate winbar string calculation that would take the window width and the components into account. This can be done in a separate follow-up PR, I believe
2. The drafts data are loaded significantly faster* than regular discussion data, this results in a short inconsistency in the winbar when manipulating the drafts - the number of drafts is updated in the winbar faster than it is rendered in the discussion tree (and before the update spinner finishes), because rebuilding the discussion tree is postponed until after all discussion data are reloaded. I believe this could be fixed by changing the order in which the data are reloaded. Consider the following pseudocode.

The current order:
```lua
draft_notes.rebuild_view = function(unlinked, all)
    discussions.rebuild_view(unlinked, all)
end
```
would change to:
```lua
discussions.rebuild_view = function(unlinked, all)
    draft_notes.rebuild_view(unlinked, all)
end
```
I haven't tried this, but I believe it would make the discrepancy between the winbar and the discussion tree much smaller. I'm going to give this a try.

\* I've made some simple measurements, and it looks like even in a very small testing repo with a very small MR (13 items in the overview) it takes about 2 seconds for the discussion tree to reload. The drafts are reloaded in fractions of a second. I'm wondering if this is just how Gitlab works, or if there may be some way to make the go server do this faster.