### PR TITLE
fix: json settings not readable on Windows

### DIFF
--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -26,7 +26,11 @@ M.start = function(callback)
   state.chosen_mr_iid = 0 -- Do not let this interfere with subsequent reviewer.open() calls
 
   local settings = vim.json.encode(go_server_settings)
-  local command = string.format("%s '%s'", state.settings.bin, settings)
+  if vim.fn.has('win32') then
+    settings = settings:gsub('"', '\\"')
+  end
+
+  local command = string.format('"%s" "%s"', state.settings.bin, settings)
 
   local job_id = vim.fn.jobstart(command, {
     on_stdout = function(_, data)


### PR DESCRIPTION
backslash doublequote created by `vim.json.encode`. This help Windows command parsing

Am I the first user of the plugin on Windows? Because, as it stands, the server can't be launched because of the parsing of the json settings into command parameters.