### PR TITLE
Fix: Remove Retry Logic

### DIFF
--- a/cmd/app/client.go
+++ b/cmd/app/client.go
@@ -68,6 +68,7 @@ func NewClient() (*Client, error) {
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = tr
+	retryClient.RetryMax = 0
 	gitlabOptions = append(gitlabOptions, gitlab.WithHTTPClient(retryClient.HTTPClient))
 
 	client, err := gitlab.NewClient(pluginOptions.AuthToken, gitlabOptions...)


### PR DESCRIPTION
This MR changes the configuration to the HTTP client so that it doesn't retry failed attempts. This behavior was causing problems when Gitlab fails with a 500 status code, but actually publishes something.