### PR TITLE
feat(pipeline): display trigger jobs for a pipeline in the pipelines popup 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ It's possible that the feature you want is already implemented, or does not belo
 
 If you are using Lazy as a plugin manager, the easiest way to work on changes is by setting a specific path for the plugin that points to your repository locally. This is what I do:
 
-```lua 
+```lua
 {
   "harrisoncramer/gitlab.nvim",
   dependencies = {
@@ -54,8 +54,8 @@ $ luacheck --globals vim busted --no-max-line-length -- .
 
 4. Make the merge request to the `develop` branch of `.gitlab.nvim`
 
-Please provide a description of the feature, and links to any relevant issues. 
+Please provide a description of the feature, and links to any relevant issues.
 
-That's it! I'll try to respond to any incoming merge request in a few days. Once we've reviewed it, it will be merged into the develop branch. 
+That's it! I'll try to respond to any incoming merge request in a few days. Once we've reviewed it, it will be merged into the develop branch.
 
 After some time, if the develop branch is found to be stable, that branch will be merged into `main` and released. When merged into `main` the pipeline will detect whether we're merging in a patch, minor, or major change, and create a new tag (e.g. 1.0.12) and release.

--- a/cmd/app/pipeline.go
+++ b/cmd/app/pipeline.go
@@ -123,11 +123,11 @@ func (a pipelineService) GetPipelineAndJobs(w http.ResponseWriter, r *http.Reque
 	bridges, res, err := a.client.ListPipelineBridges(a.projectInfo.ProjectId, pipeline.ID, &gitlab.ListJobsOptions{})
 
 	if err != nil {
-		handleError(w, err, "Could not get pipeline jobs", http.StatusInternalServerError)
+		handleError(w, err, "Could not get pipeline trigger jobs", http.StatusInternalServerError)
 		return
 	}
 	if res.StatusCode >= 300 {
-		handleError(w, GenericError{r.URL.Path}, "Could not get pipeline jobs", res.StatusCode)
+		handleError(w, GenericError{r.URL.Path}, "Could not get pipeline trigger jobs", res.StatusCode)
 		return
 	}
 
@@ -140,11 +140,11 @@ func (a pipelineService) GetPipelineAndJobs(w http.ResponseWriter, r *http.Reque
 		pipelineIdInBridge := bridge.DownstreamPipeline.ID
 		bridgePipelineJobs, res, err := a.client.ListPipelineJobs(a.projectInfo.ProjectId, pipelineIdInBridge, &gitlab.ListJobsOptions{})
 		if err != nil {
-			handleError(w, err, "Could not get pipeline jobs for bridge", http.StatusInternalServerError)
+			handleError(w, err, "Could not get jobs for a pipeline form trigger a trigger job", http.StatusInternalServerError)
 			return
 		}
 		if res.StatusCode >= 300 {
-			handleError(w, GenericError{r.URL.Path}, "Could not get pipeline jobs for bridge", res.StatusCode)
+			handleError(w, GenericError{r.URL.Path}, "Could not get jobs for a pipeline form trigger a trigger job", res.StatusCode)
 			return
 		}
 

--- a/cmd/app/pipeline.go
+++ b/cmd/app/pipeline.go
@@ -137,7 +137,7 @@ func (a pipelineService) GetPipelineAndJobs(w http.ResponseWriter, r *http.Reque
 		}
 
 		pipelineIdInBridge := bridge.DownstreamPipeline.ID
-		bridgePipelineJobs, res, err := a.client.ListPipelineJobs(a.projectInfo.ProjectId, pipelineIdInBridge, &gitlab.ListJobsOptions{})
+		bridgePipelineJobs, res, err := a.client.ListPipelineJobs(bridge.DownstreamPipeline.ProjectID, pipelineIdInBridge, &gitlab.ListJobsOptions{})
 		if err != nil {
 			handleError(w, err, "Could not get jobs for a pipeline from a trigger job", http.StatusInternalServerError)
 			return

--- a/cmd/app/pipeline.go
+++ b/cmd/app/pipeline.go
@@ -117,7 +117,7 @@ func (a pipelineService) GetPipelineAndJobs(w http.ResponseWriter, r *http.Reque
 	pipelines = append(pipelines, PipelineWithJobs{
 		Jobs:           jobs,
 		LatestPipeline: pipeline,
-		Name:           "",
+		Name:           "root",
 	})
 
 	bridges, res, err := a.client.ListPipelineBridges(a.projectInfo.ProjectId, pipeline.ID, &gitlab.ListJobsOptions{})

--- a/cmd/app/pipeline.go
+++ b/cmd/app/pipeline.go
@@ -131,7 +131,6 @@ func (a pipelineService) GetPipelineAndJobs(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Iterate through all bridges
 	for _, bridge := range bridges {
 		if bridge.DownstreamPipeline == nil {
 			continue

--- a/cmd/app/pipeline.go
+++ b/cmd/app/pipeline.go
@@ -139,11 +139,11 @@ func (a pipelineService) GetPipelineAndJobs(w http.ResponseWriter, r *http.Reque
 		pipelineIdInBridge := bridge.DownstreamPipeline.ID
 		bridgePipelineJobs, res, err := a.client.ListPipelineJobs(a.projectInfo.ProjectId, pipelineIdInBridge, &gitlab.ListJobsOptions{})
 		if err != nil {
-			handleError(w, err, "Could not get jobs for a pipeline form trigger a trigger job", http.StatusInternalServerError)
+			handleError(w, err, "Could not get jobs for a pipeline from a trigger job", http.StatusInternalServerError)
 			return
 		}
 		if res.StatusCode >= 300 {
-			handleError(w, GenericError{r.URL.Path}, "Could not get jobs for a pipeline form trigger a trigger job", res.StatusCode)
+			handleError(w, GenericError{r.URL.Path}, "Could not get jobs for a pipeline from a trigger job", res.StatusCode)
 			return
 		}
 

--- a/cmd/app/pipeline_test.go
+++ b/cmd/app/pipeline_test.go
@@ -28,11 +28,11 @@ func (f fakePipelineManager) ListPipelineJobs(pid interface{}, pipelineID int, o
 }
 
 func (f fakePipelineManager) ListPipelineBridges(pid interface{}, pipelineID int, opts *gitlab.ListJobsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Bridge, *gitlab.Response, error) {
-    resp, err := f.handleGitlabError()
-    if err != nil {
-        return nil, nil, err
-    }
-    return []*gitlab.Bridge{}, resp, err
+	resp, err := f.handleGitlabError()
+	if err != nil {
+		return nil, nil, err
+	}
+	return []*gitlab.Bridge{}, resp, err
 }
 
 func (f fakePipelineManager) RetryPipelineBuild(pid interface{}, pipeline int, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error) {

--- a/cmd/app/pipeline_test.go
+++ b/cmd/app/pipeline_test.go
@@ -27,6 +27,14 @@ func (f fakePipelineManager) ListPipelineJobs(pid interface{}, pipelineID int, o
 	return []*gitlab.Job{}, resp, err
 }
 
+func (f fakePipelineManager) ListPipelineBridges(pid interface{}, pipelineID int, opts *gitlab.ListJobsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Bridge, *gitlab.Response, error) {
+    resp, err := f.handleGitlabError()
+    if err != nil {
+        return nil, nil, err
+    }
+    return []*gitlab.Bridge{}, resp, err
+}
+
 func (f fakePipelineManager) RetryPipelineBuild(pid interface{}, pipeline int, options ...gitlab.RequestOptionFunc) (*gitlab.Pipeline, *gitlab.Response, error) {
 	resp, err := f.handleGitlabError()
 	if err != nil {

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -35,7 +35,6 @@ local function get_latest_pipelines(count)
   return pipelines
 end
 
-
 local function get_pipeline_jobs(idx)
   return u.reverse(type(state.PIPELINE[idx].jobs) == "table" and state.PIPELINE[idx].jobs or {})
 end
@@ -68,11 +67,12 @@ M.open = function()
       jobs = pipeline_jobs,
       width = width,
       height = 6 + #pipeline_jobs + 3,
-      lines = {}
+      lines = {},
     })
   end
 
-  local pipeline_popup = Popup(popup.create_popup_state("Loading Pipelines...", state.settings.popup.pipeline, max_width, total_height, 60))
+  local pipeline_popup =
+    Popup(popup.create_popup_state("Loading Pipelines...", state.settings.popup.pipeline, max_width, total_height, 60))
   popup.set_up_autocommands(pipeline_popup, nil, vim.api.nvim_get_current_win())
   M.pipeline_popup = pipeline_popup
   pipeline_popup:mount()
@@ -119,10 +119,10 @@ M.open = function()
 
     -- Add separator between pipelines
     if i < #pipelines_data then
-        table.insert(lines, "")
-        table.insert(lines, string.rep("-", max_width))
-        table.insert(lines, "")
-      end
+      table.insert(lines, "")
+      table.insert(lines, string.rep("-", max_width))
+      table.insert(lines, "")
+    end
 
     for _, line in ipairs(lines) do
       table.insert(all_lines, line)
@@ -133,7 +133,7 @@ M.open = function()
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, all_lines)
 
     local line_offset = 0
-    for i, data in ipairs(pipelines_data) do
+    for _, data in ipairs(pipelines_data) do
       local pipeline = data.pipeline
       local lines = data.lines
 
@@ -246,7 +246,12 @@ end
 ---@param wrap_with_color boolean
 ---@return string
 M.get_pipeline_status = function(idx, wrap_with_color)
-  return string.format("[%s]: Status: %s (%s)", state.PIPELINE[idx].name, M.get_pipeline_icon(idx, wrap_with_color), state.PIPELINE[idx].latest_pipeline.status)
+  return string.format(
+    "[%s]: Status: %s (%s)",
+    state.PIPELINE[idx].name,
+    M.get_pipeline_icon(idx, wrap_with_color),
+    state.PIPELINE[idx].latest_pipeline.status
+  )
 end
 
 M.color_status = function(status, bufnr, status_line, linnr)

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -59,7 +59,7 @@ M.open = function()
     max_width = math.max(max_width, width)
     local pipeline_jobs = get_pipeline_jobs(idx)
     local pipeline_status = M.get_pipeline_status(idx, false)
-    local height = 6 + #pipeline_jobs + 4
+    local height = 6 + #pipeline_jobs + 3
     total_height = total_height + height
 
     table.insert(pipelines_data, {
@@ -83,7 +83,7 @@ M.open = function()
   u.switch_can_edit_buf(bufnr, true)
 
   local all_lines = {}
-  for _, data in ipairs(pipelines_data) do
+  for i, data in ipairs(pipelines_data) do
     local pipeline = data.pipeline
     local lines = data.lines
 
@@ -118,11 +118,12 @@ M.open = function()
     end
 
     -- Add separator between pipelines
-    table.insert(lines, "")
-    table.insert(lines, string.rep("-", max_width))
-    table.insert(lines, "")
+    if i < #pipelines_data then
+        table.insert(lines, "")
+        table.insert(lines, string.rep("-", max_width))
+        table.insert(lines, "")
+      end
 
-    -- Append to all_lines
     for _, line in ipairs(lines) do
       table.insert(all_lines, line)
     end

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -245,7 +245,7 @@ end
 ---@param wrap_with_color boolean
 ---@return string
 M.get_pipeline_status = function(idx, wrap_with_color)
-  return string.format("%s (%s)", M.get_pipeline_icon(idx, wrap_with_color), state.PIPELINE[idx].latest_pipeline.status)
+  return string.format("%s %s (%s)", state.PIPELINE[idx].name, M.get_pipeline_icon(idx, wrap_with_color), state.PIPELINE[idx].latest_pipeline.status)
 end
 
 M.color_status = function(status, bufnr, status_line, linnr)

--- a/lua/gitlab/actions/pipeline.lua
+++ b/lua/gitlab/actions/pipeline.lua
@@ -59,7 +59,7 @@ M.open = function()
     max_width = math.max(max_width, width)
     local pipeline_jobs = get_pipeline_jobs(idx)
     local pipeline_status = M.get_pipeline_status(idx, false)
-    local height = 6 + #pipeline_jobs + 3
+    local height = 6 + #pipeline_jobs + 4
     total_height = total_height + height
 
     table.insert(pipelines_data, {
@@ -87,7 +87,7 @@ M.open = function()
     local pipeline = data.pipeline
     local lines = data.lines
 
-    table.insert(lines, "Status: " .. data.pipeline_status)
+    table.insert(lines, data.pipeline_status)
     table.insert(lines, "")
     table.insert(lines, string.format("Last Run: %s", u.time_since(pipeline.created_at)))
     table.insert(lines, string.format("Url: %s", pipeline.web_url))
@@ -245,7 +245,7 @@ end
 ---@param wrap_with_color boolean
 ---@return string
 M.get_pipeline_status = function(idx, wrap_with_color)
-  return string.format("%s %s (%s)", state.PIPELINE[idx].name, M.get_pipeline_icon(idx, wrap_with_color), state.PIPELINE[idx].latest_pipeline.status)
+  return string.format("[%s]: Status: %s (%s)", state.PIPELINE[idx].name, M.get_pipeline_icon(idx, wrap_with_color), state.PIPELINE[idx].latest_pipeline.status)
 end
 
 M.color_status = function(status, bufnr, status_line, linnr)


### PR DESCRIPTION
Solves https://github.com/harrisoncramer/gitlab.nvim/issues/464

Uses the [List pipeline trigger jobs](https://docs.gitlab.com/ee/api/jobs.html) api end point to retrieve the jobs triggered by the root pipeline. The jobs in these pipelines are then retrieved by [List pipeline jobs](https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs) api and populated in neovim front end as shown in the screenshot below

---

Pipeline popup window when pipeline has trigger jobs

<img src="https://github.com/user-attachments/assets/f3d6459a-591c-4c7a-815b-4b58227c0761" alt="expected _behavior" width="70%">


