### PR TITLE
Feat: Add MR URL to the summary details

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -302,6 +302,7 @@ you call this function with no values the defaults will be used:
           "delete_branch",
           "squash",
           "labels",
+          "web_url",
         },
       },
       discussion_signs = {

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -139,7 +139,7 @@ M.build_info_lines = function()
         return pipeline.status
       end,
     },
-    web_url = { title = "MR URL", content = info.web_url }
+    web_url = { title = "MR URL", content = info.web_url },
   }
 
   local longest_used = ""

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -139,6 +139,7 @@ M.build_info_lines = function()
         return pipeline.status
       end,
     },
+    web_url = { title = "MR URL", content = info.web_url }
   }
 
   local longest_used = ""

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -208,6 +208,7 @@ M.settings = {
       "delete_branch",
       "squash",
       "labels",
+      "web_url",
     },
   },
   discussion_signs = {


### PR DESCRIPTION
This is a small PR that adds the MR's Web URL to the Details of the summary popup. I sometimes find it useful to be able to *see* the URL. A workaround is to use `glu` to copy the url to clipboard and then it is shown in a message, but sometimes I just don't want to pollute the clipboard just to see a piece of information.