### PR TITLE
fix: make cycling reviewed files faster

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -316,6 +316,7 @@ you call this function with no values the defaults will be used:
           comment = "→|",
           range = " |",
         },
+        skip_old_revision_discussion = false, -- Don't show diagnostics for discussions that were created for earlier MR revisions
       },
       pipeline = {
         created = "",

--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -265,7 +265,7 @@ M.get_line_number_from_node = function(root_node)
 end
 
 -- This function (settings.keymaps.discussion_tree.jump_to_reviewer) will jump the cursor to the reviewer's location associated with the note. The implementation depends on the reviewer
-M.jump_to_reviewer = function(tree, callback)
+M.jump_to_reviewer = function(tree)
   local node = tree:get_node()
   local root_node = M.get_root_node(tree, node)
   if root_node == nil then
@@ -278,7 +278,6 @@ M.jump_to_reviewer = function(tree, callback)
     return
   end
   reviewer.jump(root_node.file_name, line_number, is_new_sha)
-  callback()
 end
 
 -- This function (settings.keymaps.discussion_tree.jump_to_file) will jump to the file changed in a new tab

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -744,6 +744,16 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
     })
   end
 
+  if keymaps.discussion_tree.print_node then
+    vim.keymap.set("n", keymaps.discussion_tree.print_node, function()
+      common.print_node(tree)
+    end, {
+      buffer = bufnr,
+      desc = "Print current node (for debugging)",
+      nowait = keymaps.discussion_tree.print_node_nowait,
+    })
+  end
+
   if keymaps.discussion_tree.add_emoji then
     vim.keymap.set("n", keymaps.discussion_tree.add_emoji, function()
       M.add_emoji_to_note(tree, unlinked)

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -74,6 +74,7 @@ M.initialize_discussions = function()
   state.discussion_tree.last_updated = os.time()
   signs.setup_signs()
   reviewer.set_callback_for_file_changed(function(args)
+    diagnostics.place_diagnostics(args.buf)
     reviewer.update_winid_for_buffer(args.buf)
   end)
   reviewer.set_callback_for_reviewer_enter(function()
@@ -90,7 +91,7 @@ M.initialize_discussions = function()
   end)
 end
 
---- Take existing data and refresh the diagnostics, the winbar, and the signs
+--- Take existing data and refresh the diagnostics and the signs
 M.refresh_diagnostics = function()
   if state.settings.discussion_signs.enabled then
     diagnostics.refresh_diagnostics()
@@ -573,7 +574,7 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
     if keymaps.discussion_tree.jump_to_reviewer then
       vim.keymap.set("n", keymaps.discussion_tree.jump_to_reviewer, function()
         if M.is_current_node_note(tree) then
-          common.jump_to_reviewer(tree, M.refresh_diagnostics)
+          common.jump_to_reviewer(tree)
         end
       end, { buffer = bufnr, desc = "Jump to reviewer", nowait = keymaps.discussion_tree.jump_to_reviewer_nowait })
     end

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -346,3 +346,15 @@
 ---@field perform_action? string -- Once in normal mode, does action (like saving comment or applying description edit, etc)
 ---@field perform_linewise_action? string -- Once in normal mode, does the linewise action (see logs for this job, etc)
 ---@field discard_changes? string -- Quit the popup discarding changes, the popup content is not? saved to the `temp_registers` (see `:h gitlab.nvim.temp-registers`)
+
+---@class List The base class for all list objects
+---@field new function -- Creates a new List from a table
+---@field map function -- Mutates a given list
+---@field filter function -- Filters a given list
+---@field partition function -- Partitions a given list into two lists
+---@field reduce function -- Applies a function to reduce the list to a single value
+---@field sort function -- Sorts the list in place based on a comparator function
+---@field find function -- Returns the first element that satisfies the callback
+---@field slice function -- Returns a portion of the list between start and end indices
+---@field includes function -- Returns true if any of the elements can satisfy the callback
+---@field values function -- Returns an iterator over the list's values


### PR DESCRIPTION
Addresses the issue described in [this comment](https://github.com/harrisoncramer/gitlab.nvim/pull/470#issuecomment-2632298958).

This fixes the diagnostics placement while also making cycling Diffview files faster by pre-computing diagnostics and removing unnecessary list filtering.