### PR TITLE
Fix: Make publishing drafts more robust

### DIFF
--- a/cmd/app/client.go
+++ b/cmd/app/client.go
@@ -68,8 +68,8 @@ func NewClient() (*Client, error) {
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = tr
-	retryClient.RetryMax = 0
 	gitlabOptions = append(gitlabOptions, gitlab.WithHTTPClient(retryClient.HTTPClient))
+	gitlabOptions = append(gitlabOptions, gitlab.WithoutRetries())
 
 	client, err := gitlab.NewClient(pluginOptions.AuthToken, gitlabOptions...)
 

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -85,6 +85,9 @@ end
 
 ---Publishes all draft notes and comments. Re-renders all discussion views.
 M.confirm_publish_all_drafts = function()
+  if not git.check_current_branch_up_to_date_on_remote(vim.log.levels.ERROR) then
+    return
+  end
   local body = { publish_all = true }
   job.run_job("/mr/draft_notes/publish", "POST", body, function(data)
     u.notify(data.message, vim.log.levels.INFO)

--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -4,6 +4,7 @@
 -- under lua/gitlab/actions/discussions/init.lua
 local common = require("gitlab.actions.common")
 local discussion_tree = require("gitlab.actions.discussions.tree")
+local git = require("gitlab.git")
 local job = require("gitlab.job")
 local NuiTree = require("nui.tree")
 local List = require("gitlab.utils.list")
@@ -92,8 +93,13 @@ M.confirm_publish_all_drafts = function()
   job.run_job("/mr/draft_notes/publish", "POST", body, function(data)
     u.notify(data.message, vim.log.levels.INFO)
     state.DRAFT_NOTES = {}
-    local discussions = require("gitlab.actions.discussions")
-    discussions.rebuild_view(false, true)
+    require("gitlab.actions.discussions").rebuild_view(false, true)
+  end, function()
+    require("gitlab.actions.discussions").rebuild_view(false, true)
+    u.notify(
+      "Draft(s) may have been published despite the error. Check the discussion tree. Try publishing drafts individually.",
+      vim.log.levels.WARN
+    )
   end)
 end
 

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -6,11 +6,9 @@ local M = {}
 ---@param command table
 ---@return string|nil, string|nil
 local run_system = function(command)
-  -- Load here to prevent loop
-  local u = require("gitlab.utils")
   local result = vim.fn.trim(vim.fn.system(command))
   if vim.v.shell_error ~= 0 then
-    u.notify(result, vim.log.levels.ERROR)
+    require("gitlab.utils").notify(result, vim.log.levels.ERROR)
     return nil, result
   end
   return result, nil

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -56,7 +56,7 @@ end
 ---@return string|nil
 M.get_remote_branch = function()
   local remote_branch, err = run_system({ "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}" })
-  if err or not remote_branch then
+  if err or remote_branch == "" then
     require("gitlab.utils").notify("Could not get remote branch: " .. err, vim.log.levels.ERROR)
     return nil
   end
@@ -130,7 +130,7 @@ end
 ---@return string|nil
 M.get_current_branch = function()
   local current_branch, err = run_system({ "git", "branch", "--show-current" })
-  if err or not current_branch then
+  if err or current_branch == "" then
     require("gitlab.utils").notify("Could not get current branch: " .. err, vim.log.levels.ERROR)
     return nil
   end


### PR DESCRIPTION
This PR attempts to fix #425.

By default the gitlab client attempts [5 retries](https://gitlab.com/gitlab-org/api/client-go/-/blob/89e6601b09ec7702973fda7d24358e7bc59e197c/gitlab.go#L326) which corresponds to the fact that it bulk publishing drafts "fails" with a server error, it still creates 1+5 copies of the comments.

Apart from finally removing the retry functionality, this MR also introduces the following improves:
- Check that the local repository is up-to-date with remote before publishing drafts (bulk or single), as I've found that draft publishing can fail when commits have been added to the MR between creating drafts in `gitlab.nvim` and publishing them (probably just when there is a comment on some code that has changed).
- Show explanation what to do when publishing drafts fails (but a draft actually has been published)
- Fetch the remote branch before checking local branch is up-to-date with remote
- Some refactoring