### PR TITLE
Fix: Swap file_name and old_file_name in reviewer data

### DIFF
--- a/cmd/app/comment_helpers.go
+++ b/cmd/app/comment_helpers.go
@@ -42,13 +42,19 @@ type RequestWithPosition interface {
 func buildCommentPosition(commentWithPositionData RequestWithPosition) *gitlab.PositionOptions {
 	positionData := commentWithPositionData.GetPositionData()
 
+	// If the file has been renamed, then this is a relevant part of the payload
+	oldFileName := positionData.OldFileName
+	if oldFileName == "" {
+		oldFileName = positionData.FileName
+	}
+
 	opt := &gitlab.PositionOptions{
 		PositionType: &positionData.Type,
 		StartSHA:     &positionData.StartCommitSHA,
 		HeadSHA:      &positionData.HeadCommitSHA,
 		BaseSHA:      &positionData.BaseCommitSHA,
 		NewPath:      &positionData.FileName,
-		OldPath:      &positionData.OldFileName,
+		OldPath:      &oldFileName,
 		NewLine:      positionData.NewLine,
 		OldLine:      positionData.OldLine,
 	}

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -153,7 +153,8 @@ M.create_comment_layout = function(opts)
     title = "Note"
     user_settings = popup_settings.note
   else
-    local file_name = M.location.reviewer_data.new_sha_focused and M.location.reviewer_data.file_name
+    local file_name = (M.location.reviewer_data.new_sha_focused or M.location.reviewer_data.old_file_name == "")
+        and M.location.reviewer_data.file_name
       or M.location.reviewer_data.old_file_name
     title =
       popup.create_title("Comment", file_name, M.location.visual_range.start_line, M.location.visual_range.end_line)

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -153,9 +153,8 @@ M.create_comment_layout = function(opts)
     title = "Note"
     user_settings = popup_settings.note
   else
-    -- TODO: investigate why `old_file_name` is in fact the new name for renamed files!
-    local file_name = M.location.reviewer_data.old_file_name ~= "" and M.location.reviewer_data.old_file_name
-      or M.location.reviewer_data.file_name
+    local file_name = M.location.reviewer_data.new_sha_focused and M.location.reviewer_data.file_name
+      or M.location.reviewer_data.old_file_name
     title =
       popup.create_title("Comment", file_name, M.location.visual_range.start_line, M.location.visual_range.end_line)
     user_settings = popup_settings.comment

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -195,10 +195,8 @@ M.get_reviewer_data = function(current_win)
   local opposite_bufnr = new_sha_focused and layout.a.file.bufnr or layout.b.file.bufnr
 
   return {
-    -- TODO: swap 'a' and 'b' to fix lua/gitlab/actions/comment.lua:158, and hopefully also
-    -- lua/gitlab/indicators/diagnostics.lua:129.
-    file_name = layout.a.file.path,
-    old_file_name = M.is_file_renamed() and layout.b.file.path or "",
+    old_file_name = M.is_file_renamed() and layout.a.file.path or "",
+    file_name = layout.b.file.path,
     old_line_from_buf = old_line,
     new_line_from_buf = new_line,
     modification_type = modification_type,

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -123,7 +123,8 @@ M.jump = function(file_name, old_file_name, line_number, new_buffer)
 
   local files = view.panel:ordered_file_list()
   local file = List.new(files):find(function(f)
-    return new_buffer and f.path == file_name or f.oldpath == old_file_name
+    local oldpath = f.oldpath ~= nil and f.oldpath or f.path
+    return new_buffer and f.path == file_name or oldpath == old_file_name
   end)
   if file == nil then
     u.notify(


### PR DESCRIPTION
This PR fixes #486 by restoring how old paths for (potentially) renamed files are handled. This requires rebuilding the Go server.

This PR fixes also the correct OLD/NEW file name assignment in the reviewer data and also the way how the file name for the comment popup title is created based on the reviewer data.