### PR TITLE
Feat: Enable toggling date format in discussions

### DIFF
--- a/after/syntax/gitlab.vim
+++ b/after/syntax/gitlab.vim
@@ -5,10 +5,11 @@ endif
 let expanders = '^\s*\%(' . g:gitlab_discussion_tree_expander_open . '\|' . g:gitlab_discussion_tree_expander_closed . '\)'
 let username = '@[a-zA-Z0-9.]\+'
 
-" Covers times like '14 days ago', 'just now', as well as 'October  3, 2024'
+" Covers times like '14 days ago', 'just now', as well as 'October  3, 2024', and '02/28/2025 at 00:50'
 let time_ago = '\d\+ \w\+ ago'
 let formatted_date = '\w\+ \{1,2}\d\{1,2}, \d\{4}'
-let date = '\%(' . time_ago . '\|' . formatted_date . '\|just now\)'
+let absolute_time = '\d\{2}/\d\{2}/\d\{4} at \d\{2}:\d\{2}'
+let date = '\%(' . time_ago . '\|' . formatted_date . '\|' . absolute_time . '\|just now\)'
 
 let published = date . ' \%(' . g:gitlab_discussion_tree_resolved . '\|' . g:gitlab_discussion_tree_unresolved . '\|' . g:gitlab_discussion_tree_unlinked . '\)\?'
 let state = ' \%(' . published . '\|' . g:gitlab_discussion_tree_draft . '\)'

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -213,6 +213,7 @@ you call this function with no values the defaults will be used:
           switch_view = "c", -- Toggle between the notes and discussions views
           toggle_tree_type = "i", -- Toggle type of discussion tree - "simple", or "by_file_name"
           publish_draft = "P", -- Publish the currently focused note/comment
+          toggle_date_format = "dt", -- Toggle between date formats: relative (e.g., "5 days ago", "just now", "October 13, 2024" for dates more than a month ago) and absolute (e.g., "03/01/2024 at 11:43")
           toggle_draft_mode = "D", -- Toggle between draft mode (comments posted as drafts) and live mode (comments are posted immediately)
           toggle_sort_method = "st", -- Toggle whether discussions are sorted by the "latest_reply", or by "original_comment", see `:h gitlab.nvim.toggle_sort_method`
           toggle_node = "t", -- Open or close the discussion
@@ -267,6 +268,7 @@ you call this function with no values the defaults will be used:
         draft = "✎", -- Symbol to show next to draft comments/notes
         tree_type = "simple", -- Type of discussion tree - "simple" means just list of discussions, "by_file_name" means file tree with discussions under file
         draft_mode = false, -- Whether comments are posted as drafts as part of a review
+        relative_date = true, -- Whether to show relative time like "5 days ago" or absolute time like "03/01/2025 at 01:43"
         winbar = nil, -- Custom function to return winbar title, should return a string. Provided with WinbarTable (defined in annotations.lua)
                      -- If using lualine, please add "gitlab" to disabled file types, otherwise you will not see the winbar.
       },

--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -15,7 +15,9 @@ M.build_note_header = function(note)
   if note.note then
     return "@" .. state.USER.username .. " " .. state.settings.discussion_tree.draft
   end
-  return "@" .. note.author.username .. " " .. u.time_since(note.created_at)
+  local time = state.settings.discussion_tree.relative_date and u.time_since(note.created_at)
+    or u.format_to_local(note.created_at, vim.fn.strftime("%z"))
+  return "@" .. note.author.username .. " " .. time
 end
 
 M.switch_can_edit_bufs = function(bool, ...)

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -649,6 +649,16 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
     })
   end
 
+  if keymaps.discussion_tree.toggle_date_format then
+    vim.keymap.set("n", keymaps.discussion_tree.toggle_date_format, function()
+      M.toggle_date_format()
+    end, {
+      buffer = bufnr,
+      desc = "Toggle date format",
+      nowait = keymaps.discussion_tree.toggle_date_format_nowait,
+    })
+  end
+
   if keymaps.discussion_tree.toggle_resolved then
     vim.keymap.set("n", keymaps.discussion_tree.toggle_resolved, function()
       if M.is_current_node_note(tree) and not M.is_draft_note(tree) then
@@ -807,6 +817,13 @@ M.toggle_sort_method = function()
   end
   winbar.update_winbar()
   M.rebuild_view(false, true)
+end
+
+---Toggle between displaying relative time (e.g., "5 days ago") and absolute time (e.g., "04/10/2025 at 22:49")
+M.toggle_date_format = function()
+  state.settings.discussion_tree.relative_date = not state.settings.discussion_tree.relative_date
+  M.rebuild_unlinked_discussion_tree()
+  M.rebuild_discussion_tree()
 end
 
 ---Indicates whether the node under the cursor is a draft note or not

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -115,6 +115,7 @@ M.settings = {
       switch_view = "c",
       toggle_tree_type = "i",
       publish_draft = "P",
+      toggle_date_format = "dt",
       toggle_draft_mode = "D",
       toggle_sort_method = "st",
       toggle_node = "t",
@@ -169,6 +170,7 @@ M.settings = {
     draft = "✎",
     tree_type = "simple",
     draft_mode = false,
+    relative_date = true,
   },
   emojis = {
     formatter = nil,


### PR DESCRIPTION
Sometime I find it useful to look at a MR discussion and see when exactly a comment was made. I can of course look at "10 days ago" and then go to the calendar and see what date that was, but that's inconvenient.

This PR makes it possible to toggle between two different formats:
- the current relative format (though this too becomes absolute after 30 days)
- absolute time like "02/28/2025 at 09:30"

This PR suggests a new keybinding `dt` (mnemonic "**d**ate **t**oggle", just like `st` is the default for "**s**ort method **t**oggle").