### PR TITLE
Fix: Add opts to help popup

### DIFF
--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -725,7 +725,7 @@ M.set_tree_keymaps = function(tree, bufnr, unlinked)
 
   if keymaps.help then
     vim.keymap.set("n", keymaps.help, function()
-      help.open()
+      help.open({ discussion_tree = true })
     end, { buffer = bufnr, desc = "Open help popup", nowait = keymaps.help_nowait })
   end
 


### PR DESCRIPTION
Addresses point 1 of #472: Information about comment types is only shown in the help popup for the discussion tree.