### PR TITLE
make path of server binary configurable

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -147,6 +147,7 @@ you call this function with no values the defaults will be used:
       port = nil, -- The port of the Go server, which runs in the background, if omitted or `nil` the port will be chosen automatically
       log_path = vim.fn.stdpath("cache") .. "/gitlab.nvim.log", -- Log path for the Go server
       config_path = nil, -- Custom path for `.gitlab.nvim` file, please read the "Connecting to Gitlab" section
+      bin = nil,  -- Custom path to Go server binary, if not set the internal one is used. Only change if really needed
       debug = {
           request = false, -- Requests to/from Go server
           response = false,

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -36,8 +36,8 @@ local function setup(args)
   if args == nil then
     args = {}
   end
-  server.build() -- Builds the Go binary if it doesn't exist
   state.merge_settings(args) -- Merges user settings with default settings
+  server.build() -- Builds the Go binary if it doesn't exist
   state.set_global_keymaps() -- Sets keymaps that are not bound to a specific buffer
   require("gitlab.colors") -- Sets colors
   reviewer.init()

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -87,7 +87,7 @@ M.build = function(override)
   state.settings.root_path = parent_dir
 
   if state.settings.bin ~= nil then
-    u.notify(string.format("skipping server intallation, using: %s", state.settings.bin), vim.log.levels.INFO)
+    u.notify(string.format("Skipping server installation, using: %s", state.settings.bin), vim.log.levels.INFO)
     return true
   end
 

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -84,9 +84,14 @@ end
 M.build = function(override)
   local file_path = u.current_file_path()
   local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h:h")
+  state.settings.root_path = parent_dir
+
+  if state.settings.bin ~= nil then
+    u.notify(string.format("skipping server intallation, using: %s", state.settings.bin), vim.log.levels.INFO)
+    return true
+  end
 
   local bin_name = u.is_windows() and "bin.exe" or "bin"
-  state.settings.root_path = parent_dir
   state.settings.bin = parent_dir .. u.path_separator .. "cmd" .. u.path_separator .. bin_name
 
   if not override then

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -46,6 +46,7 @@ M.settings = {
   auth_provider = M.default_auth_provider,
   file_separator = u.path_separator,
   port = nil, -- choose random port
+  bin = nil,  -- use the plugins internal
   debug = {
     request = false,
     response = false,


### PR DESCRIPTION
This pull request makes the path to the Go server binary configurable. If setting argument 'bin' is not 'nil' the compilation is skipped and the value of 'bin' is used to execute the Go server from.

I needed this to make it easier to use this plugin in my nix system, as the directory of the plugin is readonly in nix system the compilation fails.

Let me know whether you want met to change something.

Btw: Thanks for the work on this great plugin.