### PR TITLE
Fix: Force start_line for jumping to diagnostic to be inside buffer

### DIFF
--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -240,7 +240,9 @@ M.get_line_numbers_for_range = function(old_line, new_line, start_line_code, end
     return (old_line - range), old_line, false
   elseif new_line ~= nil then
     local range = new_end_line - new_start_line
-    return (new_line - range), new_line, true
+    -- Force start_line to be greater than 0
+    local start_line = (new_line - range > 0) and (new_line - range) or 1
+    return start_line, new_line, true
   else
     u.notify("Error getting new or old line for range", vim.log.levels.ERROR)
     return 1, 1, false

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -122,6 +122,9 @@ M.place_diagnostics = function(bufnr)
     u.notify("Could not find Diffview view", vim.log.levels.ERROR)
     return
   end
+  if vim.api.nvim_buf_get_name(bufnr) == "diffview://null" then
+    return
+  end
 
   local ok, err = pcall(function()
     local file_discussions = List.new(M.placeable_discussions):filter(function(discussion_or_note)


### PR DESCRIPTION
There could be an error when jumping to a diagnostic that was placed on a line range and some lines in that range were removed so that the start line of the diagnostic ended up outside of the buffer (e.g., line number -2).

The same bug was also responsible for diagnostics to be placed outside of buffer which was causing a full screen of errors.

Additionally, in this MR, diagnostics are not processed unnecessarily for Diffview NULL buffers (for deleted and added files).