### PR TITLE
Fix: Use file_name when old_file_name is not set

### DIFF
--- a/lua/gitlab/actions/draft_notes/init.lua
+++ b/lua/gitlab/actions/draft_notes/init.lua
@@ -155,6 +155,7 @@ M.build_root_draft_note = function(note)
     id = note.id,
     root_note_id = note.id,
     file_name = (type(note.position) == "table" and note.position.new_path or nil),
+    old_file_name = (type(note.position) == "table" and note.position.old_path or nil),
     new_line = (type(note.position) == "table" and note.position.new_line or nil),
     old_line = (type(note.position) == "table" and note.position.old_line or nil),
     resolvable = false,

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -110,6 +110,9 @@ end
 ---@param line_number number Line number from the discussion node.
 ---@param new_buffer boolean If true, jump to the NEW SHA.
 M.jump = function(file_name, old_file_name, line_number, new_buffer)
+  -- Draft comments don't have `old_file_name` set
+  old_file_name = old_file_name or file_name
+
   if M.tabnr == nil then
     u.notify("Can't jump to Diffvew. Is it open?", vim.log.levels.ERROR)
     return


### PR DESCRIPTION
This PR fixes the bug when the missing field `old_file_name` on draft comments created on the "OLD" buffer breaks jumping to reviewer.