### PR TITLE
Fix: Use path instead of oldpath as fallback for unrenamed files

### DIFF
--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -46,11 +46,11 @@ jobs:
           neovim: true
           version: ${{ matrix.nvim_version }}
       - name: Install luajit
-        uses: leafo/gh-actions-lua@v10
+        uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "luajit-openresty"
       - name: Install luarocks
-        uses: leafo/gh-actions-luarocks@v4
+        uses: leafo/gh-actions-luarocks@v5
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -51,6 +51,8 @@ jobs:
           luaVersion: "luajit-openresty"
       - name: Install luarocks
         uses: leafo/gh-actions-luarocks@v5
+        with:
+          luarocksVersion: "3.8.0"
       - name: Run tests
         shell: bash
         run: |

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -240,7 +240,7 @@ end
 ---@return string|nil
 M.get_current_file_oldpath = function()
   local file_data = M.get_current_file_data()
-  return file_data and file_data.oldpath
+  return file_data and file_data.oldpath or file_data.path
 end
 
 ---Tell whether current file is renamed or not


### PR DESCRIPTION
Hi @harrisoncramer, I will be very grateful if you could have a look at this PR (and those other I've opened recently). They mostly fix some smaller bugs or add some small features that I find useful (like the [date format toggling](https://github.com/harrisoncramer/gitlab.nvim/pull/491)).

In DiffView, `oldpath` is set to `nil` in unrenamed files, and this causes the `git diff` command (lua/gitlab/hunks.lua lines 101-108) to return a diff for *all* files instead of a single file. This in turn can cause incorrect modification type identification (e.g., lua/gitlab/hunks.lua line 204) because the algorithm can incorrectly identify a line to be [in_new_range](https://github.com/jakubbortlik/gitlab.nvim/blob/475ad9194dec636ccb914ecc680d2cff70a00d0d/lua/gitlab/hunks.lua#L204) even if it's in fact looking at a diff of a completely different file.

This primarily fixes some incorrectly identified comments on unchanged text, but maybe it will also prevent some of the pesky "invalid line code" errors that still occur from time to time.