### PR TITLE
cancel CI workflow that becomes obsolete after a new commit is pushed…

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,6 +8,11 @@ on:
       - 'cmd/**' # Ignore changes to the Lua code
       - 'go.sum'
       - 'go.mod'
+
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   go_lint:
     name: Lint Go 💅 


### PR DESCRIPTION
### Change Summary
Currently, if a PR is open and a push happens, the **Go** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus saving compute resources (see below for quantity) without sacrificing functionality, since the second run will contain the changes from the first push as well.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Here is an example of the behaviour described above: the commit `91a6210` triggered [this](https://github.com/harrisoncramer/gitlab.nvim/actions/runs/11306215007/) workflow run, and shortly after the commit `b98b385`, that happened on top of the first commit, triggered [this](https://github.com/harrisoncramer/gitlab.nvim/actions/runs/11306218411/) workflow. Both workflows ran till the end, spending approximately 3 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~3.0 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run, the accumulated gain for all workflows would be higher.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

PS: Some hyperlinks may not work if the corresponding workflows have been deleted.