### PR TITLE
feat: enable setting discussion tree options

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -1078,4 +1078,25 @@ execute and passed the data as an argument.
           with each resource as a key-value pair, with the key being it's
           type.
 
+                                                                *gitlab.nvim.data*
+gitlab.refresh_data() ~
+
+Fetches discussion tree data from Gitlab and refreshes the tree views. It can
+be used in an autocommand to refresh the data every time you enter the
+discussion tree. This exmaple shows how to easily limit the refresh rate to at
+least 10 seconds:
+>lua
+  local last_updated = os.time()
+  local gitlab = vim.api.nvim_create_augroup("Gitlab", {})
+  vim.api.nvim_create_autocmd("BufEnter", {
+    group = gitlab,
+    callback = function()
+      if vim.bo.filetype == "gitlab" and os.time() - last_updated > 10 then
+        require("gitlab").refresh_data()
+        last_updated = os.time()
+      end
+    end
+  })
+<
+
 vim:tw=78:ts=4:sw=4:expandtab:ft=help:norl:

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -270,6 +270,12 @@ you call this function with no values the defaults will be used:
         tree_type = "simple", -- Type of discussion tree - "simple" means just list of discussions, "by_file_name" means file tree with discussions under file
         draft_mode = false, -- Whether comments are posted as drafts as part of a review
         relative_date = true, -- Whether to show relative time like "5 days ago" or absolute time like "03/01/2025 at 01:43"
+        winopts = { -- Window-local options for the discussion tree split
+          number = false,
+          relativenumber = false,
+          breakindent = true, -- Every wrapped line will continue visually indented
+          showbreak = "+ ", -- String to put at the start of lines that have been wrapped
+        }
         winbar = nil, -- Custom function to return winbar title, should return a string. Provided with WinbarTable (defined in annotations.lua)
                      -- If using lualine, please add "gitlab" to disabled file types, otherwise you will not see the winbar.
       },

--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -25,7 +25,6 @@ M.switch_can_edit_bufs = function(bool, ...)
   ---@param v integer
   for _, v in ipairs(bufnrs) do
     u.switch_can_edit_buf(v, bool)
-    vim.api.nvim_set_option_value("filetype", "gitlab", { buf = v })
   end
 end
 

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -115,6 +115,13 @@ M.open = function(callback, view_type)
   M.linked_bufnr = linked_bufnr
   M.unlinked_bufnr = unlinked_bufnr
 
+  for opt, val in pairs(state.settings.discussion_tree.winopts) do
+    vim.api.nvim_set_option_value(opt, val, { win = M.split.winid })
+  end
+
+  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.linked_bufnr })
+  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.unlinked_bufnr })
+
   M.split = split
   M.split_visible = true
   split:mount()
@@ -451,8 +458,6 @@ M.rebuild_discussion_tree = function()
   M.set_tree_keymaps(discussion_tree, M.linked_bufnr, false)
   M.discussion_tree = discussion_tree
   common.switch_can_edit_bufs(false, M.linked_bufnr, M.unlinked_bufnr)
-  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.linked_bufnr })
-  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.unlinked_bufnr })
   state.discussion_tree.resolved_expanded = false
   state.discussion_tree.unresolved_expanded = false
 end

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -115,10 +115,6 @@ M.open = function(callback, view_type)
   M.linked_bufnr = linked_bufnr
   M.unlinked_bufnr = unlinked_bufnr
 
-  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.split.bufnr })
-  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.unlinked_bufnr })
-  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.linked_bufnr })
-
   M.split = split
   M.split_visible = true
   split:mount()
@@ -456,6 +452,7 @@ M.rebuild_discussion_tree = function()
   M.discussion_tree = discussion_tree
   common.switch_can_edit_bufs(false, M.linked_bufnr, M.unlinked_bufnr)
   vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.linked_bufnr })
+  vim.api.nvim_set_option_value("filetype", "gitlab", { buf = M.unlinked_bufnr })
   state.discussion_tree.resolved_expanded = false
   state.discussion_tree.unresolved_expanded = false
 end

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -172,6 +172,12 @@ M.settings = {
     tree_type = "simple",
     draft_mode = false,
     relative_date = true,
+    winopts = {
+      number = false,
+      relativenumber = false,
+      breakindent = true,
+      showbreak = "+ ",
+    },
   },
   emojis = {
     formatter = nil,


### PR DESCRIPTION
This PR makes it possible to set window-local options for the discussion tree and also sets some useful defaults.

I've also limited the number of times when `gitlab` filetype is set.

Also adds description of refresh_data API function to the docs.