### PR TITLE
fix: put attach_file markdown on new line

### DIFF
--- a/lua/gitlab/actions/miscellaneous.lua
+++ b/lua/gitlab/actions/miscellaneous.lua
@@ -27,7 +27,7 @@ M.attach_file = function()
     local body = { file_path = full_path, file_name = choice }
     job.run_job("/attachment", "POST", body, function(data)
       local markdown = data.markdown
-      vim.api.nvim_put({markdown}, "l", true, false)
+      vim.api.nvim_put({ markdown }, "l", true, false)
     end)
   end)
 end

--- a/lua/gitlab/actions/miscellaneous.lua
+++ b/lua/gitlab/actions/miscellaneous.lua
@@ -27,9 +27,7 @@ M.attach_file = function()
     local body = { file_path = full_path, file_name = choice }
     job.run_job("/attachment", "POST", body, function(data)
       local markdown = data.markdown
-      local current_line = u.get_current_line_number()
-      local bufnr = vim.api.nvim_get_current_buf()
-      vim.api.nvim_buf_set_lines(bufnr, current_line - 1, current_line, false, { markdown })
+      vim.api.nvim_put({markdown}, "l", true, false)
     end)
   end)
 end


### PR DESCRIPTION
With this change, the attach_file markdown is put on a new line below the cursor instead of replacing the current line. This simplifies the usage by not requiring the user to create the new empty line first.