### PR TITLE
fix: start and clean up winbar timer properly

### DIFF
--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -124,6 +124,7 @@ M.open = function(callback, view_type)
   split:mount()
 
   -- Initialize winbar module with data from buffers
+  winbar.start_timer()
   winbar.set_buffers(M.linked_bufnr, M.unlinked_bufnr)
   winbar.switch_view_type(view_type)
 
@@ -156,6 +157,7 @@ M.close = function()
   end
   M.split_visible = false
   M.discussion_tree = nil
+  winbar.cleanup_timer()
 end
 
 ---Move to the discussion tree at the discussion from diagnostic on current line.

--- a/lua/gitlab/actions/discussions/winbar.lua
+++ b/lua/gitlab/actions/discussions/winbar.lua
@@ -271,8 +271,21 @@ M.switch_view_type = function(override)
   M.update_winbar()
 end
 
--- Set up a timer to update the winbar periodically
-local timer = vim.uv.new_timer()
-timer:start(0, 100, vim.schedule_wrap(M.update_winbar))
+---Set up a timer to update the winbar periodically
+M.start_timer = function()
+  M.cleanup_timer()
+  ---@type nil|uv_timer_t
+  M.timer = vim.uv.new_timer()
+  M.timer:start(0, 100, vim.schedule_wrap(M.update_winbar))
+end
+
+--Stop and close the timer
+M.cleanup_timer = function()
+  if M.timer ~= nil then
+    M.timer:stop()
+    M.timer:close()
+    M.timer = nil
+  end
+end
 
 return M

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -78,6 +78,7 @@ M.open = function()
   local on_diffview_closed = function(view)
     if view.tabpage == M.tabnr then
       M.tabnr = nil
+      require("gitlab.actions.discussions.winbar").cleanup_timer()
     end
   end
   require("diffview.config").user_emitter:on("view_closed", function(_, args)


### PR DESCRIPTION
This PR fixes the bug that the winbar timer is never properly stopped and is running even after the reviewer or the discussion tree has been closed. This is not a major issue, but the plugin should properly clean up the state after the review has been closed.