### PR TITLE
fix: check window valid when refocusing after closing popup

### DIFF
--- a/lua/gitlab/popup.lua
+++ b/lua/gitlab/popup.lua
@@ -166,7 +166,9 @@ M.set_up_autocommands = function(popup, layout, previous_window, opts)
   if previous_window ~= nil then
     popup:on("BufHidden", function()
       vim.schedule(function()
-        vim.api.nvim_set_current_win(previous_window)
+        if vim.api.nvim_win_is_valid(previous_window) then
+          vim.api.nvim_set_current_win(previous_window)
+        end
       end)
     end)
   end


### PR DESCRIPTION
This PR fixes the error that is thrown if the last active window from which a popup was opened is no longer valid when closing the popup.

Reproduction steps:
- Start a review: `glS`
- Focus the discussion tree if not already focused
- type `gls` to show the summary
- type `gld` to hide the discussion tree
- type `gls` to close the summary