### PR TITLE
feat: better handling of server installation path

### DIFF
--- a/.github/workflows/update-gomod2nix.yaml
+++ b/.github/workflows/update-gomod2nix.yaml
@@ -1,0 +1,30 @@
+name: Update gomod2nix
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - go.mod
+      - go.sum
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Generate gomod2nix.toml
+        run: nix run github:nix-community/gomod2nix -- generate
+
+      - name: Commit updated gomod2nix.toml
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update gomod2nix.toml"
+          file_pattern: gomod2nix.toml

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -144,7 +144,10 @@ Here is the default setup function. All of these values are optional, and if
 you call this function with no values the defaults will be used:
 >lua
     require("gitlab").setup({
-      port = nil, -- The port of the Go server, which runs in the background, if omitted or `nil` the port will be chosen automatically
+      server = {
+        binary = nil, -- The path to the server binary. If omitted or nil, the server will be built
+        port = nil, -- The port of the Go server, which runs in the background. If omitted or `nil` the port will be chosen automatically
+      },
       log_path = vim.fn.stdpath("cache") .. "/gitlab.nvim.log", -- Log path for the Go server
       config_path = nil, -- Custom path for `.gitlab.nvim` file, please read the "Connecting to Gitlab" section
       debug = {
@@ -711,7 +714,7 @@ by a |motion|.
 Either the operator or the motion can be preceded by a count, so that `3sj` is
 equivalent to `s3j`, and they both create a comment for the current line and
 three more lines downwards. Similarly, both `2s`|ap| and `s2`|ap| create a suggestion
-for two "outer" paragraphs. 
+for two "outer" paragraphs.
 
 The operators force |linewise| visual selection, so they work correctly even
 if the motion itself works |characterwise| (e.g., |i(| for selecting the inner

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770770419,
+        "narHash": "sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c5e707c6b5339359a9a9e215c5e66d6d802fd7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+        gitlab-nvim-server = pkgs.buildGoModule {
+          pname = "gitlab.nvim-server";
+          version = "git";
+          src = ./.;
+          vendorHash = "sha256-OLAKTdzqynBDHqWV5RzIpfc3xZDm6uYyLD4rxbh0DMg=";
+          postInstall = ''
+            cp -r ${./cmd/config} $out/bin/config
+            mv $out/bin/cmd $out/bin/gitlab.nvim
+          '';
+        };
+        gitlab-nvim = pkgs.vimUtils.buildVimPlugin {
+          name = "gitlab.nvim";
+          src = ./.;
+          doCheck = false;
+        };
+      in
+      rec {
+        formatter = pkgs.nixpkgs-fmt;
+        packages.gitlab-nvim-server = gitlab-nvim-server;
+        packages.gitlab-nvim = gitlab-nvim;
+        packages.default = packages.gitlab-nvim;
+        devShell = pkgs.mkShell {
+          packages = with pkgs; [
+            git
+            go
+            go-tools
+            golangci-lint
+            luajitPackages.busted
+            luajitPackages.luacheck
+            luajitPackages.luarocks
+            neovim
+            stylua
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   outputs = { self, flake-utils, nixpkgs }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+        pkgs = import nixpkgs { inherit system; };
         gitlab-nvim-server = pkgs.buildGoModule {
           pname = "gitlab.nvim-server";
           version = "git";
@@ -24,12 +24,12 @@
           doCheck = false;
         };
       in
-      rec {
+      {
         formatter = pkgs.nixpkgs-fmt;
         packages.gitlab-nvim-server = gitlab-nvim-server;
         packages.gitlab-nvim = gitlab-nvim;
-        packages.default = packages.gitlab-nvim;
-        devShell = pkgs.mkShell {
+        packages.default = gitlab-nvim;
+        devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             git
             go

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,25 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
+    gomod2nix = {
+      url = "github:nix-community/gomod2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, flake-utils, nixpkgs }:
+  outputs = { self, flake-utils, nixpkgs, gomod2nix }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs { inherit system; };
-        gitlab-nvim-server = pkgs.buildGoModule {
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ gomod2nix.overlays.default ];
+        };
+        gitlab-nvim-server = pkgs.buildGoApplication {
           pname = "gitlab.nvim-server";
           version = "git";
           src = ./.;
-          vendorHash = "sha256-OLAKTdzqynBDHqWV5RzIpfc3xZDm6uYyLD4rxbh0DMg=";
+          modules = ./gomod2nix.toml;
+          subPackages = [ "cmd" ];
           postInstall = ''
             cp -r ${./cmd/config} $out/bin/config
             mv $out/bin/cmd $out/bin/gitlab.nvim
@@ -34,6 +42,7 @@
             git
             go
             go-tools
+            gomod2nix
             golangci-lint
             luajitPackages.busted
             luajitPackages.luacheck

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,66 @@
+schema = 3
+
+[mod]
+  [mod.'github.com/gabriel-vasile/mimetype']
+    version = 'v1.4.3'
+    hash = 'sha256-EDmlRi3av27dq/ISVTglv08z4yZzMQ/SxL1c46EJro0='
+
+  [mod.'github.com/go-playground/locales']
+    version = 'v0.14.1'
+    hash = 'sha256-BMJGAexq96waZn60DJXZfByRHb8zA/JP/i6f/YrW9oQ='
+
+  [mod.'github.com/go-playground/universal-translator']
+    version = 'v0.18.1'
+    hash = 'sha256-2/B2qP51zfiY+k8G0w0D03KXUc7XpWj6wKY7NjNP/9E='
+
+  [mod.'github.com/go-playground/validator/v10']
+    version = 'v10.22.1'
+    hash = 'sha256-EsgeltH0ow6saxLvTFVtIyHVqWI3Fiu1AE2Qmnsmowg='
+
+  [mod.'github.com/google/go-cmp']
+    version = 'v0.7.0'
+    hash = 'sha256-JbxZFBFGCh/Rj5XZ1vG94V2x7c18L8XKB0N9ZD5F2rM='
+
+  [mod.'github.com/google/go-querystring']
+    version = 'v1.2.0'
+    hash = 'sha256-F/Ve4oDaEqho8RryvdGSRR22/DbYHWZQa6M60n6oSYM='
+
+  [mod.'github.com/hashicorp/go-cleanhttp']
+    version = 'v0.5.2'
+    hash = 'sha256-N9GOKYo7tK6XQUFhvhImtL7PZW/mr4C4Manx/yPVvcQ='
+
+  [mod.'github.com/hashicorp/go-retryablehttp']
+    version = 'v0.7.8'
+    hash = 'sha256-4LZwKaFBbpKi9lSq5y6lOlYHU6WMnQdGNMxTd33rN80='
+
+  [mod.'github.com/leodido/go-urn']
+    version = 'v1.4.0'
+    hash = 'sha256-Q6kplWkY37Tzy6GOme3Wut40jFK4Izun+ij/BJvcEu0='
+
+  [mod.'gitlab.com/gitlab-org/api/client-go']
+    version = 'v1.17.0'
+    hash = 'sha256-PdVbuFXCp/TphltAkpJG3YNXhtqHnhhyel9KLUX/xz0='
+
+  [mod.'golang.org/x/crypto']
+    version = 'v0.19.0'
+    hash = 'sha256-Vi6vY/eWNlYQ9l3Y+gA+X2+h2CmzEOrBRVFO/cnrPWc='
+
+  [mod.'golang.org/x/net']
+    version = 'v0.21.0'
+    hash = 'sha256-LfiqMpPtqvW/eLkfx6Ebr5ksqKbQli6uq06c/+XrBsw='
+
+  [mod.'golang.org/x/oauth2']
+    version = 'v0.34.0'
+    hash = 'sha256-5eqpGGxJ7FJsPmfRek6roeGmkWHBMJaWYXyz8gXJsS4='
+
+  [mod.'golang.org/x/sys']
+    version = 'v0.39.0'
+    hash = 'sha256-dxTBu/JAWUkPbjFIXXRFdhQWyn+YyEpIC+tWqGo0Y6U='
+
+  [mod.'golang.org/x/text']
+    version = 'v0.32.0'
+    hash = 'sha256-9PXtWBKKY9rG4AgjSP4N+I1DhepXhy8SF/vWSIDIoWs='
+
+  [mod.'golang.org/x/time']
+    version = 'v0.14.0'
+    hash = 'sha256-fVjpq0ieUHVEOTSElDVleMWvfdcqojZchqdUXiC7NnY='

--- a/lua-test.sh
+++ b/lua-test.sh
@@ -41,4 +41,4 @@ done
 
 # Run tests
 echo "Running tests with Neovim..."
-nvim -u NONE -U NONE -N -i NONE -l tests/init.lua "$@"
+LC_TIME=en_US.UTF-8 nvim -u NONE -U NONE -N -i NONE -l tests/init.lua "$@"

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -148,7 +148,7 @@
 --- Plugin Settings
 ---
 ---@class Settings
----@field port? number -- The port of the Go server, which runs in the background, if omitted or `nil` the port will be chosen automatically
+---@field server ServerSettings
 ---@field remote_branch "origin" | string -- The remote, "origin" by default
 ---@field log_path? string -- Log path for the Go server
 ---@field string? any -- Custom path for `.gitlab.nvim` file, please read the "Connecting to Gitlab" section
@@ -166,6 +166,10 @@
 ---@field pipeline? PipelineSettings -- The settings for the pipeline popup
 ---@field create_mr? CreateMrSettings -- The settings when creating an MR
 ---@field colors? ColorSettings --- Colors settings for the plugin
+
+---@class ServerSettings
+---@field port? number -- The port of the Go server, which runs in the background, if omitted or `nil` the port will be chosen automatically
+---@field binary? string -- The path to the server binary. If omitted or nil, the server will be built
 
 ---@class DiscussionSigns: table
 ---@field enabled? boolean -- Show diagnostics for gitlab comments in the reviewer

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -45,8 +45,8 @@ local function setup(args)
     return
   end
 
-  server.build() -- Builds the Go binary if it doesn't exist
   state.merge_settings(args) -- Merges user settings with default settings
+  server.build() -- Builds the Go binary if it doesn't exist
   state.set_global_keymaps() -- Sets keymaps that are not bound to a specific buffer
   require("gitlab.colors") -- Sets colors
   reviewer.init()

--- a/lua/gitlab/job.lua
+++ b/lua/gitlab/job.lua
@@ -7,10 +7,6 @@ local M = {}
 M.run_job = function(endpoint, method, body, callback, on_error_callback)
   local state = require("gitlab.state")
   local port = state.settings.server and state.settings.server.port
-  if state.settings.port ~= nil then
-    port = state.settings.port
-    u.notify("The setting `port` has been renamed `server.port`", vim.log.levels.WARN)
-  end
   local args = { "-s", "-X", (method or "POST"), string.format("localhost:%s%s", port, endpoint) }
 
   if body ~= nil then

--- a/lua/gitlab/job.lua
+++ b/lua/gitlab/job.lua
@@ -6,7 +6,12 @@ local M = {}
 
 M.run_job = function(endpoint, method, body, callback, on_error_callback)
   local state = require("gitlab.state")
-  local args = { "-s", "-X", (method or "POST"), string.format("localhost:%s", state.settings.port) .. endpoint }
+  local port = state.settings.server and state.settings.server.port
+  if state.settings.port ~= nil then
+    port = state.settings.port
+    u.notify("The setting `port` has been renamed `server.port`", vim.log.levels.WARN)
+  end
+  local args = { "-s", "-X", (method or "POST"), string.format("localhost:%s%s", port, endpoint) }
 
   if body ~= nil then
     local encoded_body = vim.json.encode(body)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -30,6 +30,10 @@ end
 
 -- Starts the Go server and call the callback provided
 M.start = function(callback)
+  if state.settings.port ~= nil and state.settings.server.port == nil then
+    state.settings.server.port = state.settings.port
+    u.notify("The setting `port` has been renamed `server.port`", vim.log.levels.WARN)
+  end
   local port = tonumber(state.settings.server.port) or 0
   local parsed_port = nil
   local callback_called = false
@@ -104,8 +108,7 @@ end
 
 -- Builds the Go binary with the current Git tag.
 M.build = function(override)
-  local file_path = u.current_file_path()
-  state.settings.root_path = vim.fn.fnamemodify(file_path, ":h:h:h:h")
+  state.settings.root_path = u.get_root_path()
 
   -- If the user provided a path to the server, don't build it.
   if state.settings.server.binary ~= nil then
@@ -218,8 +221,7 @@ M.get_version = function(callback)
     u.notify("Gitlab server not running", vim.log.levels.ERROR)
     return nil
   end
-  local file_path = u.current_file_path()
-  local parent_dir = vim.fn.fnamemodify(file_path, ":h:h:h:h")
+  local parent_dir = u.get_root_path()
 
   local version_output = vim.system({ "git", "describe", "--tags", "--always" }, { cwd = parent_dir }):wait()
   local plugin_version = version_output.code == 0 and vim.trim(version_output.stdout) or "unknown"

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -46,7 +46,10 @@ end
 M.settings = {
   auth_provider = M.default_auth_provider,
   file_separator = u.path_separator,
-  port = nil, -- choose random port
+  server = {
+    binary = nil,
+    port = nil,
+  },
   debug = {
     request = false,
     response = false,

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -509,6 +509,12 @@ M.current_file_path = function()
   return vim.fn.fnamemodify(path, ":p")
 end
 
+-- Returns the root path of the plugin (four levels up from this file: lua/gitlab/utils/init.lua)
+M.get_root_path = function()
+  local path = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(path, ":p:h:h:h:h")
+end
+
 local random = math.random
 M.uuid = function()
   local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -504,11 +504,6 @@ M.read_file = function(file_path, opts)
   return file_contents
 end
 
-M.current_file_path = function()
-  local path = debug.getinfo(1, "S").source:sub(2)
-  return vim.fn.fnamemodify(path, ":p")
-end
-
 -- Returns the root path of the plugin (four levels up from this file: lua/gitlab/utils/init.lua)
 M.get_root_path = function()
   local path = debug.getinfo(1, "S").source:sub(2)


### PR DESCRIPTION
Closes #493

I also use Nix to configure my NeoVim installation. The modifications in this MR make it possible to use the plugin this way, or with another form of distribution that does not provide git or has a read-only plugin folder.

This is achieved by:

1. Instead of hard-coding the server binary path to the plugin folder, use `vim.fn.stdpath("data")`. This is the correct place to put it in. But anyway, don't assume it's writable, and try it and all folders in the runtime to find one that we can write to, and put it there. The data folder is most probably going to be writable, but this way we can at least have more options before failing. This is already done by NeoVim itself when you try to install a spell dictionary, for example, or a tree-sitter grammar, so it is a safe way to handle this that aligns with existing practices.
2. Give the user the option of pointing to an existing server, because why not?

To this end I changed the configuration structure to have a `server` key with a `binary` sub-key, and moved the `port` option inside it, for coherence.

The init script was changed to set the configuration before building, as we now need the configuration during the build.

The build function was, of course, the most affected by the changes.

A `flake.nix` is provided that make it easy to use the plugin with nix. It offers the plugin and server, so the user can decide if they want to let the plugin build the server as usual or if they want to let nix manage the build and just point to it in their configuration.

The server assumes the path of the emoji configuration file. I don't understand why the file is provided like that, could it not be embedded in the binary? Maybe its path could be passed as configuration by Lua when launching it? I decided to not change it though, and just make sure the config folder is where the server expects it to be.