### PR TITLE
fix: use pagination to list MR discussions

### DIFF
--- a/cmd/app/list_discussions.go
+++ b/cmd/app/list_discussions.go
@@ -123,7 +123,7 @@ func (a discussionsListerService) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	/* Collect IDs in order to fetch emojis */
 	var noteIds []int64
-	for _, discussion := range discussions {
+	for _, discussion := range slices.Concat(linkedDiscussions, unlinkedDiscussions) {
 		for _, note := range discussion.Notes {
 			noteIds = append(noteIds, note.ID)
 		}

--- a/cmd/app/list_discussions_test.go
+++ b/cmd/app/list_discussions_test.go
@@ -127,17 +127,6 @@ func TestListDiscussions(t *testing.T) {
 		data, _ := getFailData(t, svc, request)
 		checkErrorFromGitlab(t, data, "Could not list discussions")
 	})
-	t.Run("Handles non-200s from Gitlab client", func(t *testing.T) {
-		request := makeRequest(t, http.MethodPost, "/mr/discussions/list", DiscussionsRequest{Blacklist: []string{}})
-		svc := middleware(
-			discussionsListerService{testProjectData, fakeDiscussionsLister{testBase: testBase{status: http.StatusSeeOther}}},
-			withMr(testProjectData, fakeMergeRequestLister{}),
-			withPayloadValidation(methodToPayload{http.MethodPost: newPayload[DiscussionsRequest]}),
-			withMethodCheck(http.MethodPost),
-		)
-		data, _ := getFailData(t, svc, request)
-		checkNon200(t, data, "Could not list discussions", "/mr/discussions/list")
-	})
 	t.Run("Handles error from emoji service", func(t *testing.T) {
 		request := makeRequest(t, http.MethodPost, "/mr/discussions/list", DiscussionsRequest{Blacklist: []string{}})
 		svc := middleware(


### PR DESCRIPTION
Closes #182.

This uses the `gitlab.Scan` function to iterate over all discussions and handle errors after the iterator is exhausted. The test for non-200s is no longer needed as the Scan function transforms such responses to standard errors.

This PR also limits the number of API calls for emojis by only fetching emojis for the filtered discussions.

I've tested both fixes in a large MR and it correctly fetched all discussions (that were otherwise not fetched without the pagination) and emojis.