### PR TITLE
feat!: implement AutoMerge option to AcceptMergeRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ glrd	Delete reviewer
 glA	Approve MR
 glR	Revoke MR approval
 glM	Merge the feature branch to the target branch and close MR
+glm	Set MR to merge automatically when the pipeline succeeds
 glC	Create a new MR for currently checked-out feature branch
 glc	Chose MR for review
 glS	Start review for the currently checked-out branch

--- a/cmd/app/merge_mr.go
+++ b/cmd/app/merge_mr.go
@@ -8,6 +8,7 @@ import (
 )
 
 type AcceptMergeRequestRequest struct {
+	AutoMerge     bool   `json:"auto_merge"`
 	DeleteBranch  bool   `json:"delete_branch"`
 	SquashMessage string `json:"squash_message"`
 	Squash        bool   `json:"squash"`
@@ -27,6 +28,7 @@ func (a mergeRequestAccepterService) ServeHTTP(w http.ResponseWriter, r *http.Re
 	payload := r.Context().Value(payload("payload")).(*AcceptMergeRequestRequest)
 
 	opts := gitlab.AcceptMergeRequestOptions{
+		AutoMerge:                &payload.AutoMerge,
 		Squash:                   &payload.Squash,
 		ShouldRemoveSourceBranch: &payload.DeleteBranch,
 	}
@@ -47,7 +49,13 @@ func (a mergeRequestAccepterService) ServeHTTP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	response := SuccessResponse{Message: "MR merged successfully"}
+	var message string
+	if payload.AutoMerge {
+		message = "MR set to be merged when all checks pass"
+	} else {
+		message = "MR merged successfully"
+	}
+	response := SuccessResponse{Message: message}
 
 	w.WriteHeader(http.StatusOK)
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -179,6 +179,7 @@ you call this function with no values the defaults will be used:
           approve = "glA", -- Approve MR
           revoke = "glR", -- Revoke MR approval
           merge = "glM", -- Merge the feature branch to the target branch and close MR
+          set_auto_merge = "glm", -- Set MR to merge automatically when the pipeline succeeds
           create_mr = "glC", -- Create a new MR for currently checked-out feature branch
           choose_merge_request = "glc", -- Chose MR for review (if necessary check out the feature branch)
           start_review = "glS", -- Start review for the currently checked-out branch

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -1117,7 +1117,7 @@ execute and passed the data as an argument.
           with each resource as a key-value pair, with the key being it's
           type.
 
-                                                        *gitlab.nvim.refresh_data*
+                                                                *gitlab.nvim.refresh_data*
 gitlab.refresh_data() ~
 
 Fetches discussion tree data from Gitlab and refreshes the tree views. It can

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -9,7 +9,7 @@ Table of Contents                              *gitlab.nvim.table-of-contents*
   - Connecting to Gitlab                    |gitlab.nvim.connecting-to-gitlab|
   - Configuring the Plugin                |gitlab.nvim.configuring-the-plugin|
   - Usage                                                  |gitlab.nvim.usage|
-  - The Summary view                            |gitlab.nvim.the-summary-view|
+  - The Summary view                                |gitlab.nvim.summary-view|
   - Reviewing an MR                              |gitlab.nvim.reviewing-an-mr|
   - Temporary registers                           |gitlab.nvim.temp-registers|
   - Discussions and Notes                  |gitlab.nvim.discussions-and-notes|
@@ -308,6 +308,7 @@ you call this function with no values the defaults will be used:
           "pipeline",
           "branch",
           "target_branch",
+          "auto_merge",
           "delete_branch",
           "squash",
           "labels",
@@ -415,7 +416,7 @@ Then open Neovim. To begin, try running the `summary` command or the `review`
 command.
 
 
-THE SUMMARY VIEW                                *gitlab.nvim.the-summary-view*
+THE SUMMARY VIEW                                    *gitlab.nvim.summary-view*
 
 The `summary` action will open the MR title and description:
 >lua
@@ -1058,18 +1059,25 @@ Copies the URL of the current MR to system clipboard.
                                                                 *gitlab.nvim.merge*
 gitlab.merge({opts}) ~
 
-Merges the merge request into the target branch. When run without any
-arguments, the `merge` action will respect the "Squash commits" and "Delete
-source branch" settings set by `require("gitlab").create_mr()` or set in
-Gitlab online. You can see the current settings in the Summary view, see
-|gitlab.nvim.the-summary-view|.
+Merges a mergeable merge request into the target branch. The behaviour can be
+configured with the `opts` parameter. By default, the `merge` action respects
+the "Auto-merge" setting, and the "Squash commits" and "Delete source branch"
+settings set by `require("gitlab").create_mr()` (or in Gitlab's "Edit merge
+request" page). You can see the current settings in the Summary view, see
+|gitlab.nvim.summary-view|. 
 >lua
   require("gitlab").merge()
-  require("gitlab").merge({ squash = false, delete_branch = true })
+  require("gitlab").merge({
+      auto_merge = true, squash = false, delete_branch = false
+  })
 <
     Parameters: ~
         • {opts}: (table|nil) Keyword arguments that can be used to override
-          default behavior.
+          individual current settings.
+            • {auto_merge}: (bool) If true, the merge request is set to merge
+              automatically when the pipeline succeeds. If false, an immediate
+              merge is attempted. Currently, the plugin doesn't allow
+              cancelling the auto-merge.
             • {delete_branch}: (bool) If true, the source branch will be
               deleted.
             • {squash}: (bool) If true, the commits will be squashed. If

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -12,19 +12,23 @@ local function create_squash_message_popup()
 end
 
 ---@class MergeOpts
+---@field auto_merge boolean?
 ---@field delete_branch boolean?
 ---@field squash boolean?
 ---@field squash_message string?
 
 ---@param opts MergeOpts
 M.merge = function(opts)
-  local merge_body = { squash = state.INFO.squash, delete_branch = state.INFO.delete_branch }
-  if opts then
-    merge_body.squash = opts.squash ~= nil and opts.squash
-    merge_body.delete_branch = opts.delete_branch ~= nil and opts.delete_branch
+  local merge_body = {
+    auto_merge = state.INFO.merge_when_pipeline_succeeds,
+    squash = state.INFO.squash,
+    delete_branch = state.INFO.force_remove_source_branch,
+  }
+  for key, val in pairs(opts or {}) do
+    merge_body[key] = val
   end
 
-  if state.INFO.detailed_merge_status ~= "mergeable" then
+  if state.INFO.detailed_merge_status ~= "mergeable" and not merge_body.auto_merge then
     u.notify(string.format("MR not mergeable, currently '%s'", state.INFO.detailed_merge_status), vim.log.levels.ERROR)
     return
   end

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -148,6 +148,7 @@ M.build_info_lines = function()
     branch = { title = "Branch", content = info.source_branch },
     labels = { title = "Labels", content = table.concat(info.labels, ", ") },
     target_branch = { title = "Target Branch", content = info.target_branch },
+    auto_merge = { title = "Auto-merge", content = (info.merge_when_pipeline_succeeds and "Yes" or "No") },
     delete_branch = {
       title = "Delete Source Branch",
       content = (info.force_remove_source_branch and "Yes" or "No"),

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -255,7 +255,7 @@
 
 ---@class InfoSettings
 ---@field horizontal? boolean -- Display metadata to the left of the summary rather than underneath
----@field fields? ("author" | "created_at" | "updated_at" | "merge_status" | "draft" | "conflicts" | "assignees" | "reviewers" | "pipeline" | "branch" | "target_branch" | "delete_branch" | "squash" | "labels" | "web_url" | "mergeability_checks")[]
+---@field fields? ("author" | "created_at" | "updated_at" | "merge_status" | "draft" | "conflicts" | "assignees" | "reviewers" | "pipeline" | "branch" | "target_branch" | "auto_merge" | "delete_branch" | "squash" | "labels" | "web_url" | "mergeability_checks")[]
 
 ---@class MergeabilityChecksSettings
 ---@field statuses MergeabilityStatuses

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -215,6 +215,7 @@ M.settings = {
       "pipeline",
       "branch",
       "target_branch",
+      "auto_merge",
       "delete_branch",
       "squash",
       "labels",

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -82,6 +82,7 @@ M.settings = {
       approve = "glA",
       revoke = "glR",
       merge = "glM",
+      set_auto_merge = "glm",
       create_mr = "glC",
       choose_merge_request = "glc",
       start_review = "glS",
@@ -418,6 +419,12 @@ M.set_global_keymaps = function()
     vim.keymap.set("n", keymaps.global.merge, function()
       require("gitlab").merge()
     end, { desc = "Merge MR", nowait = keymaps.global.merge_nowait })
+  end
+
+  if keymaps.global.set_auto_merge then
+    vim.keymap.set("n", keymaps.global.set_auto_merge, function()
+      require("gitlab").merge({auto_merge = true})
+    end, { desc = "Set MR to auto-merge", nowait = keymaps.global.set_auto_merge_nowait })
   end
 
   if keymaps.global.copy_mr_url then

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -423,7 +423,7 @@ M.set_global_keymaps = function()
 
   if keymaps.global.set_auto_merge then
     vim.keymap.set("n", keymaps.global.set_auto_merge, function()
-      require("gitlab").merge({auto_merge = true})
+      require("gitlab").merge({ auto_merge = true })
     end, { desc = "Set MR to auto-merge", nowait = keymaps.global.set_auto_merge_nowait })
   end
 


### PR DESCRIPTION
Closes #518.

This PR also fixes a bug when the `Delete source branch` setting of the MR was not respected due to incorrect reference in `lua/gitlab/actions/merge.lua` to `state.INFO.delete_branch` instead of `state.INFO.force_remove_source_branch`.

This PR also changes the behaviour of how the `opts` in `gitlab.merge(opts)` behave:

- Before this PR:
  - when `lua require("gitlab").merge()` was run without parameters, the values visible in the Summary view were used (except for the bug mentioned above).
  - specifying one of `squash` or `delete_branch` in `opts` caused the other parameter to default to `false` even if Summary view would show it's set to `true`.

- After this PR:
  - running `lua require("gitlab").merge()` without parameters doesn't change.
  - specifying any of the `opts` values (`auto_merge`, `squash`, `delete_branch`), has no effect on the other options - if not specified in the `gitlab.merge()` call, the values from the Summary are used.

This is a breaking change since before, a user could rely on the fact that ignoring one of the options would set it to `false` which now is not guaranteed - the value depends on the existing MR settings, which I find to be the desirable behaviour:
- only override what needs to be overridden
- only one set of default values (those in the Summary)