### PR TITLE
feat: implement rebasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Neovim plugin is designed to make it easy to review Gitlab MRs from within the editor. This means you can do things like:
 
-- Create, approve, and merge MRs for the current branch
+- Create, approve, rebase, and merge MRs for the current branch
 - Read and edit an MR description
 - Add or remove reviewers and assignees
 - Resolve, reply to, and unresolve discussion threads
@@ -144,9 +144,13 @@ glA	Approve MR
 glR	Revoke MR approval
 glM	Merge the feature branch to the target branch and close MR
 glm	Set MR to merge automatically when the pipeline succeeds
+glrr	Rebase the feature branch of the MR on the server (if not already rebased) and pull the new state
+glrs	Same as `glrr`, but skip the CI pipeline
+glrf	Same as `glrr`, but rebase even if MR already is rebased
 glC	Create a new MR for currently checked-out feature branch
 glc	Chose MR for review
 glS	Start review for the currently checked-out branch
+gl<C-R>	Load new MR state from Gitlab and apply new diff refs to the diff view
 gls	Show the editable summary of the MR
 glu	Copy the URL of the MR to the system clipboard
 glo	Open the URL of the MR in the default Internet browser

--- a/cmd/app/rebase_mr.go
+++ b/cmd/app/rebase_mr.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+type RebaseMrRequest struct {
+	SkipCI bool `json:"skip_ci,omitempty"`
+}
+
+type MergeRequestRebaser interface {
+	RebaseMergeRequest(pid interface{}, mergeRequest int64, opt *gitlab.RebaseMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
+}
+
+type MergeRequestRebaserClient interface {
+	MergeRequestRebaser
+	MergeRequestGetter
+}
+
+type mergeRequestRebaserService struct {
+	data
+	client MergeRequestRebaserClient
+}
+
+/* Rebases a merge request on the server */
+func (a mergeRequestRebaserService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	payload := r.Context().Value(payload("payload")).(*RebaseMrRequest)
+
+	opts := gitlab.RebaseMergeRequestOptions{
+		SkipCI: &payload.SkipCI,
+	}
+
+	res, err := a.client.RebaseMergeRequest(a.projectInfo.ProjectId, a.projectInfo.MergeId, &opts)
+	if err != nil {
+		handleError(w, err, "Could not rebase MR", http.StatusInternalServerError)
+		return
+	}
+
+	if res.StatusCode >= 300 {
+		handleError(w, GenericError{r.URL.Path}, "Could not rebase MR", res.StatusCode)
+		return
+	}
+
+	// Poll until rebase completes (GitLab rebase is async)
+	for {
+		mr, _, getMrErr := a.client.GetMergeRequest(
+			a.projectInfo.ProjectId,
+			a.projectInfo.MergeId,
+			&gitlab.GetMergeRequestsOptions{
+				IncludeRebaseInProgress: gitlab.Ptr(true),
+			},
+		)
+		if getMrErr != nil {
+			handleError(w, getMrErr, "Could not check rebase status", http.StatusInternalServerError)
+			return
+		}
+		if !mr.RebaseInProgress {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	skippingCI := ""
+	if payload.SkipCI {
+		skippingCI = " (skipping CI)"
+	}
+	response := SuccessResponse{Message: fmt.Sprintf("MR rebased on server%s", skippingCI)}
+
+	w.WriteHeader(http.StatusOK)
+
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		handleError(w, err, "Could not encode response", http.StatusInternalServerError)
+	}
+}

--- a/cmd/app/rebase_mr_test.go
+++ b/cmd/app/rebase_mr_test.go
@@ -1,0 +1,110 @@
+package app
+
+import (
+	"net/http"
+	"testing"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+type fakeMergeRequestRebaserClient struct {
+	testBase
+	rebaseInProgressCount int // number of times to return RebaseInProgress: true
+	getMergeRequestCalls  int // tracks how many times GetMergeRequest was called
+}
+
+func (f *fakeMergeRequestRebaserClient) RebaseMergeRequest(pid interface{}, mergeRequest int64, opt *gitlab.RebaseMergeRequestOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error) {
+	resp, err := f.handleGitlabError()
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, err
+}
+
+func (f *fakeMergeRequestRebaserClient) GetMergeRequest(pid interface{}, mergeRequest int64, opt *gitlab.GetMergeRequestsOptions, options ...gitlab.RequestOptionFunc) (*gitlab.MergeRequest, *gitlab.Response, error) {
+	resp, err := f.handleGitlabError()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f.getMergeRequestCalls++
+	rebaseInProgress := f.getMergeRequestCalls <= f.rebaseInProgressCount
+
+	return &gitlab.MergeRequest{RebaseInProgress: rebaseInProgress}, resp, err
+}
+
+func TestRebaseHandler(t *testing.T) {
+	var testRebaseMrPayload = RebaseMrRequest{SkipCI: false}
+	t.Run("Rebases merge request when rebase completes immediately", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/mr/rebase", testRebaseMrPayload)
+		fakeClient := &fakeMergeRequestRebaserClient{rebaseInProgressCount: 0}
+		svc := middleware(
+			mergeRequestRebaserService{testProjectData, fakeClient},
+			withMr(testProjectData, fakeMergeRequestLister{}),
+			withPayloadValidation(methodToPayload{
+				http.MethodPost: newPayload[RebaseMrRequest],
+			}),
+			withMethodCheck(http.MethodPost),
+		)
+		data := getSuccessData(t, svc, request)
+		assert(t, data.Message, "MR rebased on server")
+		assert(t, fakeClient.getMergeRequestCalls, 1)
+	})
+	t.Run("Rebases merge request and polls until rebase completes", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/mr/rebase", testRebaseMrPayload)
+		fakeClient := &fakeMergeRequestRebaserClient{rebaseInProgressCount: 1}
+		svc := middleware(
+			mergeRequestRebaserService{testProjectData, fakeClient},
+			withMr(testProjectData, fakeMergeRequestLister{}),
+			withPayloadValidation(methodToPayload{
+				http.MethodPost: newPayload[RebaseMrRequest],
+			}),
+			withMethodCheck(http.MethodPost),
+		)
+		data := getSuccessData(t, svc, request)
+		assert(t, data.Message, "MR rebased on server")
+		assert(t, fakeClient.getMergeRequestCalls, 2)
+	})
+	var testRebaseMrPayloadSkipCI = RebaseMrRequest{SkipCI: true}
+	t.Run("Rebases merge request and skips CI", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/mr/rebase", testRebaseMrPayloadSkipCI)
+		fakeClient := &fakeMergeRequestRebaserClient{}
+		svc := middleware(
+			mergeRequestRebaserService{testProjectData, fakeClient},
+			withMr(testProjectData, fakeMergeRequestLister{}),
+			withPayloadValidation(methodToPayload{
+				http.MethodPost: newPayload[RebaseMrRequest],
+			}),
+			withMethodCheck(http.MethodPost),
+		)
+		data := getSuccessData(t, svc, request)
+		assert(t, data.Message, "MR rebased on server (skipping CI)")
+	})
+	t.Run("Handles errors from Gitlab client", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/mr/rebase", testRebaseMrPayload)
+		svc := middleware(
+			mergeRequestRebaserService{testProjectData, &fakeMergeRequestRebaserClient{testBase: testBase{errFromGitlab: true}}},
+			withMr(testProjectData, fakeMergeRequestLister{}),
+			withPayloadValidation(methodToPayload{
+				http.MethodPost: newPayload[RebaseMrRequest],
+			}),
+			withMethodCheck(http.MethodPost),
+		)
+		data, _ := getFailData(t, svc, request)
+		checkErrorFromGitlab(t, data, "Could not rebase MR")
+	})
+	t.Run("Handles non-200s from Gitlab", func(t *testing.T) {
+		request := makeRequest(t, http.MethodPost, "/mr/rebase", testRebaseMrPayload)
+		svc := middleware(
+			mergeRequestRebaserService{testProjectData, &fakeMergeRequestRebaserClient{testBase: testBase{status: http.StatusSeeOther}}},
+			withMr(testProjectData, fakeMergeRequestLister{}),
+			withPayloadValidation(methodToPayload{
+				http.MethodPost: newPayload[RebaseMrRequest],
+			}),
+			withMethodCheck(http.MethodPost),
+		)
+		data, _ := getFailData(t, svc, request)
+		checkNon200(t, data, "Could not rebase MR", "/mr/rebase")
+	})
+}

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -117,6 +117,12 @@ func CreateRouter(gitlabClient *Client, projectInfo *ProjectInfo, s *shutdownSer
 		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[AcceptMergeRequestRequest]}),
 		withMethodCheck(http.MethodPost),
 	))
+	m.HandleFunc("/mr/rebase", middleware(
+		mergeRequestRebaserService{d, gitlabClient},
+		withMr(d, gitlabClient),
+		withPayloadValidation(methodToPayload{http.MethodPost: newPayload[RebaseMrRequest]}),
+		withMethodCheck(http.MethodPost),
+	))
 	m.HandleFunc("/mr/discussions/list", middleware(
 		discussionsListerService{d, gitlabClient},
 		withMr(d, gitlabClient),

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -33,7 +33,7 @@ OVERVIEW                                                *gitlab.nvim.overview*
 This Neovim plugin is designed to make it easy to review Gitlab MRs from within
 the editor. This means you can do things like:
 
-- Create, approve, and merge MRs for the current branch
+- Create, approve, rebase, and merge MRs for the current branch
 - Read and edit an MR description
 - Add or remove reviewers and assignees
 - Resolve, reply to, and unresolve discussion threads
@@ -183,9 +183,13 @@ you call this function with no values the defaults will be used:
           revoke = "glR", -- Revoke MR approval
           merge = "glM", -- Merge the feature branch to the target branch and close MR
           set_auto_merge = "glm", -- Set MR to merge automatically when the pipeline succeeds
+          rebase = "glrr", -- Rebase the feature branch of the MR on the server and pull the new state
+          rebase_skip_ci = "glrs", -- Same as `rebase`, but skip the CI pipeline
+          rebase_force = "glrf", -- Same as `rebase`, but rebase even if MR already is rebased
           create_mr = "glC", -- Create a new MR for currently checked-out feature branch
           choose_merge_request = "glc", -- Chose MR for review (if necessary check out the feature branch)
           start_review = "glS", -- Start review for the currently checked-out branch
+          reload_review = "gl<C-R>", -- Load new MR state from Gitlab and apply new diff refs to the diff view
           summary = "gls", -- Show the editable summary of the MR
           copy_mr_url = "glu", -- Copy the URL of the MR to the system clipboard
           open_in_browser = "glo", -- Openthe URL of the MR in the default Internet browser
@@ -390,6 +394,10 @@ you call this function with no values the defaults will be used:
           width = 40,
           border = "rounded",
         },
+      },
+      rebase_mr = {
+        skip_ci = false, -- If true, a CI pipeline is not created. Can be overridden in gitlab.rebase call.
+        force = false, --  If true, MR is rebased even if MR already is rebased. Can be overridden in gitlab.rebase call.
       },
       colors = {
         discussion_tree = {
@@ -612,6 +620,19 @@ this command to work.
     require("gitlab").merge({ squash = false, delete_branch = false })
 <
 See |gitlab.nvim.merge| for more help on this function.
+
+
+REBASING AN MR                                      *gitlab.nvim.rebasing-an-mr*
+
+The `rebase` action will rebase an MR on the server, wait for the rebase to
+take effect and then update the local reviewer state. The MR must be in a
+"rebasable" state for this command to work, i.e., the worktree must be clean
+and there must be no conflicts with the target branch.
+>lua
+    require("gitlab").rebase()
+    require("gitlab").rebase({ skip_ci = true, force = true })
+<
+See |gitlab.nvim.rebase| for more help on this function.
 
 
 CREATING AN MR                                    *gitlab.nvim.creating-an-mr*
@@ -838,6 +859,25 @@ Opens the reviewer pane. Can be used from anywhere within Neovim after the
 plugin is loaded. If run twice, will open a second reviewer pane.
 >lua
   require("gitlab").review()
+<
+                                                                *gitlab.nvim.reload_review*
+gitlab.reload_review() ~
+
+Loads new MR state from Gitlab. Then if diffview.api is available (with the
+https://github.com/dlyongemallo/diffview.nvim fork) applies the new diff refs
+to the existing diffview, otherwise (with
+https://github.com/sindrets/diffview.nvim) closes and re-opens the reviewer.
+
+>lua
+  require("gitlab").reload_review()
+<
+                                                                *gitlab.nvim.close_review*
+gitlab.close_review() ~
+
+Closes the reviewer tab and discussion tree and cleans up (e.g., removes
+winbar timer).
+>lua
+  require("gitlab").close_review()
 <
                                                                 *gitlab.nvim.summary*
 gitlab.summary() ~
@@ -1090,6 +1130,25 @@ request" page). You can see the current settings in the Summary view, see
               message. To use the default message, leave the popup empty.
               Use the `keymaps.popup.perform_action` to merge the MR
               with your message.
+
+                                                                *gitlab.nvim.rebase*
+gitlab.rebase({opts}) ~
+
+Rebases the feature branch of the MR on the server, pulls the new state, and
+updates the reviewer.
+>lua
+  require("gitlab").rebase()
+  require("gitlab").rebase({ skip_ci = true, force = true })
+<
+    Parameters: ~
+        • {opts}: (table|nil) Keyword arguments that can be used to override
+          default behavior.
+            • {skip_ci}: (`bool?`, default: `false`) If true, a CI pipeline is
+              not created (this may lead to a failed Mergeability Check
+              CI_MUST_PASS).
+            • {force}: (`bool?`, default: `false`) If true, MR is rebased even
+              if MR already is rebased (this may run an unnecessary CI
+              pipeline).
 
                                                                 *gitlab.nvim.data*
 gitlab.data({resources}, {cb}) ~

--- a/lua/gitlab/actions/comment.lua
+++ b/lua/gitlab/actions/comment.lua
@@ -300,14 +300,14 @@ end
 ---@return boolean
 M.can_create_comment = function(must_be_visual)
   -- Check that diffview is initialized
-  if reviewer.tabnr == nil then
+  if reviewer.tabid == nil then
     u.notify("Reviewer must be initialized first", vim.log.levels.ERROR)
     return false
   end
 
   -- Check that we are in the Diffview tab
-  local tabnr = vim.api.nvim_get_current_tabpage()
-  if tabnr ~= reviewer.tabnr then
+  local tabid = vim.api.nvim_get_current_tabpage()
+  if tabid ~= reviewer.tabid then
     u.notify("Comments can only be left in the reviewer pane", vim.log.levels.ERROR)
     return false
   end

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -56,8 +56,13 @@ end
 ---@param callback function|nil
 M.load_discussions = function(callback)
   local git = require("gitlab.git")
-  local ahead, behind = git.get_ahead_behind(git.get_current_branch(), git.get_remote_branch())
-  state.ahead_behind = { ahead, behind }
+  require("gitlab.git_async").get_ahead_behind(
+    git.get_current_branch(),
+    git.get_remote_branch(),
+    function(ahead, behind)
+      state.ahead_behind = { ahead, behind }
+    end
+  )
   state.discussion_tree.last_updated = nil
   state.load_new_state("discussion_data", function(data)
     if not state.DISCUSSION_DATA then

--- a/lua/gitlab/actions/rebase.lua
+++ b/lua/gitlab/actions/rebase.lua
@@ -1,0 +1,104 @@
+-- This module is responsible for rebasing the MR on the Gitlab server and updating the local
+-- branch and reviewer state.
+
+local M = {}
+
+---@class RebaseOpts
+---@field skip_ci boolean? If true, a CI pipeline is not created.
+---@field force boolean? If true, MR is rebased even if MR already is rebased.
+
+---@param opts RebaseOpts
+local can_rebase = function(opts)
+  local u = require("gitlab.utils")
+  -- Check if there are local changes (we wouldn't be able to run `git pull` after rebasing)
+  local has_clean_tree, err = require("gitlab.git").has_clean_tree()
+  if not has_clean_tree then
+    u.notify("Cannot rebase when there are changed files", vim.log.levels.ERROR)
+    return false
+  elseif err ~= nil then
+    u.notify("Error while inspecting working tree", vim.log.levels.ERROR)
+    return false
+  end
+
+  local state = require("gitlab.state")
+
+  local already_rebased = vim.iter(state.MERGEABILITY):find(function(check)
+    return check.identifier == "NEED_REBASE" and check.status == "SUCCESS"
+  end)
+
+  local force = require("gitlab.state").settings.rebase_mr.force
+  if opts.force ~= nil then
+    force = opts.force
+  end
+
+  if already_rebased and not force then
+    u.notify("MR is already rebased", vim.log.levels.ERROR)
+    return false
+  end
+
+  local has_conflicts = vim.iter(state.MERGEABILITY):find(function(check)
+    return check.identifier == "CONFLICT" and check.status ~= "SUCCESS" and check.status ~= "INACTIVE"
+  end)
+  if has_conflicts then
+    if has_conflicts.status == "FAILED" then
+      u.notify("Rebase locally, resolve all conflicts, then push the branch", vim.log.levels.ERROR)
+    else
+      u.notify("Check for conflicts hasn't passed successfully", vim.log.levels.WARN)
+    end
+    return false
+  end
+
+  return true
+end
+
+---Callback to run after the async `git pull` call exits
+---@param result string|nil The stdout from the `git pull` call if any.
+---@param err string|nil The stderr from the `git pull` call if any.
+local on_pull_exit = function(result, err)
+  if result ~= nil then
+    local reviewer = require("gitlab.reviewer")
+    if reviewer.tabid ~= nil then
+      reviewer.reload()
+    end
+  elseif err ~= nil then
+    require("gitlab.utils").notify(err, vim.log.levels.ERROR)
+  end
+end
+
+---@class RebaseBody
+---@field skip_ci boolean? If true, a CI pipeline is not created.
+
+---@param rebase_body RebaseBody
+local confirm_rebase = function(rebase_body)
+  local u = require("gitlab.utils")
+  u.notify("Rebase in progress", vim.log.levels.INFO)
+  local job = require("gitlab.job")
+  job.run_job("/mr/rebase", "POST", rebase_body, function(data)
+    u.notify(data.message .. ", updating local state", vim.log.levels.INFO)
+    local state = require("gitlab.state")
+    require("gitlab.git_async").pull(
+      state.settings.connection_settings.remote,
+      state.INFO.source_branch,
+      on_pull_exit,
+      { "--rebase" }
+    )
+  end)
+end
+
+---@param opts RebaseOpts
+M.rebase = function(opts)
+  opts = opts or {}
+
+  if not can_rebase(opts) then
+    return
+  end
+
+  local rebase_body = { skip_ci = require("gitlab.state").settings.rebase_mr.skip_ci }
+  if opts.skip_ci ~= nil then
+    rebase_body.skip_ci = opts.skip_ci
+  end
+
+  confirm_rebase(rebase_body)
+end
+
+return M

--- a/lua/gitlab/actions/summary.lua
+++ b/lua/gitlab/actions/summary.lua
@@ -32,6 +32,8 @@ M.summary = function()
     return
   end
 
+  require("gitlab.git_async").check_current_branch_up_to_date_on_remote()
+
   local title = state.INFO.title
   local description_lines = common.build_content(state.INFO.description)
   local info_lines = state.settings.info.enabled and M.build_info_lines() or { "" }
@@ -89,7 +91,6 @@ M.summary = function()
     vim.api.nvim_set_current_buf(description_popup.bufnr)
   end)
 
-  git.check_current_branch_up_to_date_on_remote(vim.log.levels.WARN)
   git.check_mr_in_good_condition()
 end
 

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -165,6 +165,7 @@
 ---@field discussion_signs? DiscussionSigns -- The settings for discussion signs/diagnostics
 ---@field pipeline? PipelineSettings -- The settings for the pipeline popup
 ---@field create_mr? CreateMrSettings -- The settings when creating an MR
+---@field rebase_mr? RebaseMrSettings -- The settings when rebasing an MR
 ---@field colors? ColorSettings --- Colors settings for the plugin
 
 ---@class ServerSettings
@@ -202,6 +203,10 @@
 ---@field squash? boolean -- Whether the commits will be marked for squashing
 ---@field title_input? TitleInputSettings
 ---@field fork? ForkSettings
+
+---@class RebaseMrSettings: table
+---@field skip_ci? boolean -- If true, a CI pipeline is not created.
+---@field force? boolean -- If true, MR is rebased even if MR already is rebased.
 
 ---@class ForkSettings: table
 ---@field enabled? boolean -- If making an MR from a fork
@@ -369,6 +374,7 @@
 ---@field create_mr? string -- Create a new MR for currently checked-out feature branch
 ---@field choose_merge_request? string -- Chose MR for review (if necessary check out the feature branch)
 ---@field start_review? string -- Start review for the currently checked-out branch
+---@field reload_review? string -- Load new MR state from Gitlab and apply new diff refs to the diff view
 ---@field summary? string -- Show the editable summary of the MR
 ---@field copy_mr_url? string -- Copy the URL of the MR to the system clipboard
 ---@field open_in_browser? string -- Openthe URL of the MR in the default Internet browser

--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -23,7 +23,7 @@ M.branches = function(args)
   return run_system(u.combine({ "git", "branch" }, args or {}))
 end
 
----Returns true if the working tree hasn't got any changes that haven't been commited
+---Returns true if the working tree hasn't got any changes that haven't been committed
 ---@return boolean, string|nil
 M.has_clean_tree = function()
   local changes, err = run_system({ "git", "status", "--short", "--untracked-files=no" })
@@ -63,9 +63,13 @@ end
 
 ---Fetch the remote branch
 ---@param remote_branch string The name of the repo and branch to fetch (e.g., "origin/some_branch")
----@return boolean fetch_successfull False if an error occurred while fetching, true otherwise.
+---@return boolean fetch_successful False if an error occurred while fetching, true otherwise.
 M.fetch_remote_branch = function(remote_branch)
-  local remote, branch = string.match(remote_branch, "([^/]+)/(.*)")
+  local remote, branch = string.match(remote_branch, "([^/]+)/(.+)")
+  if not remote or not branch then
+    require("gitlab.utils").notify("Invalid remote branch format: " .. remote_branch, vim.log.levels.ERROR)
+    return false
+  end
   local _, fetch_err = run_system({ "git", "fetch", remote, branch })
   if fetch_err ~= nil then
     require("gitlab.utils").notify("Error fetching remote-tracking branch: " .. fetch_err, vim.log.levels.ERROR)
@@ -163,13 +167,13 @@ M.contains_branch = function(current_branch)
   return run_system({ "git", "branch", "-r", "--contains", current_branch })
 end
 
----Returns true if `branch` is up-to-date on remote, otherwise false and warns user
----@param log_level integer
+--- Returns true if `branch` is up-to-date on remote, otherwise false and warns user
+---@param ahead integer|nil The number of commits the current branch is ahead of remote
+---@param behind integer|nil The number of commits the current branch is behind remote
+---@param remote_branch string|nil The remote branch, e.g., origin/feature-branch
+---@param log_level number
 ---@return boolean
-M.check_current_branch_up_to_date_on_remote = function(log_level)
-  local current_branch = M.get_current_branch()
-  local remote_branch = M.get_remote_branch()
-  local ahead, behind = M.get_ahead_behind(current_branch, remote_branch)
+M.evaluate_ahead_behind = function(ahead, behind, remote_branch, log_level)
   if ahead == nil or behind == nil then
     return false
   end
@@ -197,6 +201,19 @@ M.check_current_branch_up_to_date_on_remote = function(log_level)
   end
 
   return true -- Checks passed, branch is up-to-date
+end
+
+--- Returns true if `branch` is up-to-date on remote, otherwise false and notifies user.
+--- This is a blocking function. For a non-blocking version use
+--- gitlab.git_async.check_current_branch_up_to_date_on_remote.
+---@param log_level number The log level with which user will be notified
+---@return boolean
+M.check_current_branch_up_to_date_on_remote = function(log_level)
+  local current_branch = M.get_current_branch()
+  local remote_branch = M.get_remote_branch()
+  local ahead, behind = M.get_ahead_behind(current_branch, remote_branch)
+  require("gitlab.state").ahead_behind = { ahead, behind }
+  return M.evaluate_ahead_behind(ahead, behind, remote_branch, log_level)
 end
 
 ---Warns user if the current MR is in a bad state (closed, has conflicts, merged)

--- a/lua/gitlab/git_async.lua
+++ b/lua/gitlab/git_async.lua
@@ -1,0 +1,123 @@
+local M = {}
+
+---Function to run when an async system call finishes. Receives the command's stdout as result when
+---successful, or the command's stderr as err when unsuccessful.
+---@alias OnExitCallback fun(result:string|nil, err:string|nil)
+
+---Function to run on the result of getting the ahead and behind in the get_ahead_behind function.
+---@alias GetAheadBehindCallback fun(ahead:integer|nil, behind:integer|nil, remote_branch:string|nil)
+
+---Runs a system command asynchronously
+---@param command string[]
+---@param on_exit OnExitCallback
+local run_system_async = function(command, on_exit)
+  vim.system(command, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        require("gitlab.utils").notify(result.stderr, vim.log.levels.ERROR)
+        on_exit(nil, result.stderr)
+      else
+        on_exit(vim.fn.trim(result.stdout), nil)
+      end
+    end)
+  end)
+end
+
+---Pull a branch asynchronously from a remote and execute callback on exit.
+---@param remote string The remote from which to pull.
+---@param branch string The branch to pull.
+---@param on_exit OnExitCallback The callback to execute when the command finishes.
+---@param args? string[] Extra arguments passed to the `git pull` command.
+M.pull = function(remote, branch, on_exit, args)
+  local current_branch = require("gitlab.git").get_current_branch()
+  if not current_branch then
+    return
+  end
+  if current_branch ~= branch then
+    on_exit(nil, "Cannot pull. Remote branch is not the same as current branch")
+    return
+  end
+  local cmd = { "git", "pull" }
+  vim.list_extend(cmd, args or {})
+  vim.list_extend(cmd, { remote, branch })
+  run_system_async(cmd, on_exit)
+end
+
+---Fetch the remote branch
+---@param remote_branch string The name of the repo and branch to fetch (e.g., "origin/some_branch")
+---@param on_exit OnExitCallback
+M.fetch_remote_branch = function(remote_branch, on_exit)
+  local remote, branch = string.match(remote_branch, "([^/]+)/(.+)")
+  if not remote or not branch then
+    on_exit(nil, "Invalid remote branch format: " .. remote_branch)
+    return
+  end
+  run_system_async({ "git", "fetch", remote, branch }, on_exit)
+end
+
+--- Determines the number of commits the current branch is ahead of or behind the remote branch and
+--- runs on_exit callback with the values.
+---@param current_branch string|nil
+---@param remote_branch string|nil
+---@param on_exit GetAheadBehindCallback
+M.get_ahead_behind = function(current_branch, remote_branch, on_exit)
+  if current_branch == nil or remote_branch == nil then
+    on_exit(nil, nil, remote_branch)
+    return
+  end
+
+  ---Callback to run after the async `git fetch` call exits
+  ---@param result string|nil The stdout from the `git fetch` call if any.
+  ---@param err string|nil The stderr from the `git fetch` call if any.
+  local fetch_remote_branch_callback = function(result, err)
+    if result ~= nil then
+      local u = require("gitlab.utils")
+      run_system_async(
+        { "git", "rev-list", "--left-right", "--count", current_branch .. "..." .. remote_branch },
+        --- The function to run after the async `git rev-list` call exits
+        ---@param r string|nil The stdout from the `git rev-list` call if any.
+        ---@param e string|nil The stderr from the `git rev-list` call if any.
+        function(r, e)
+          if e ~= nil or r == nil then
+            u.notify("Could not determine if branch is up-to-date: " .. (e or "unknown error"), vim.log.levels.ERROR)
+            on_exit(nil, nil, remote_branch)
+            return
+          end
+          local ahead, behind = r:match("(%d+)%s+(%d+)")
+          if ahead == nil or behind == nil then
+            u.notify("Error parsing ahead/behind information", vim.log.levels.ERROR)
+            on_exit(nil, nil, remote_branch)
+            return
+          end
+          on_exit(tonumber(ahead), tonumber(behind), remote_branch)
+        end
+      )
+    elseif err ~= nil then
+      require("gitlab.utils").notify("Error fetching remote-tracking branch: " .. err, vim.log.levels.ERROR)
+      on_exit(nil, nil, remote_branch)
+    end
+  end
+
+  M.fetch_remote_branch(remote_branch, fetch_remote_branch_callback)
+end
+
+---Callback to run on the result of getting the ahead and behind in the get_ahead_behind function.
+---@param ahead integer|nil The number of commits the current branch is ahead of remote
+---@param behind integer|nil The number of commits the current branch is behind remote
+---@param remote_branch string|nil The remote from which to pull.
+local check_up_to_date_callback = function(ahead, behind, remote_branch)
+  require("gitlab.state").ahead_behind = { ahead, behind }
+  require("gitlab.git").evaluate_ahead_behind(ahead, behind, remote_branch, vim.log.levels.WARN)
+end
+
+--- Evaluates if `branch` is up-to-date on remote and warns user.
+--- This is a non-blocking function. For a blocking version that can be used to abort further
+--- execution if branch is not up-to-date use gitlab.git.check_current_branch_up_to_date_on_remote.
+M.check_current_branch_up_to_date_on_remote = function()
+  local git = require("gitlab.git")
+  local current_branch = git.get_current_branch()
+  local remote_branch = git.get_remote_branch()
+  M.get_ahead_behind(current_branch, remote_branch, check_up_to_date_callback)
+end
+
+return M

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -1,5 +1,4 @@
 local u = require("gitlab.utils")
-local diffview_lib = require("diffview.lib")
 local indicators_common = require("gitlab.indicators.common")
 local actions_common = require("gitlab.actions.common")
 local List = require("gitlab.utils.list")
@@ -102,7 +101,7 @@ M.refresh_diagnostics = function()
   M.clear_diagnostics()
   M.placeable_discussions = indicators_common.filter_placeable_discussions()
 
-  local view = diffview_lib.get_current_view()
+  local view = require("gitlab.reviewer").diffview
   if view == nil then
     u.notify("Could not find Diffview view", vim.log.levels.ERROR)
     return
@@ -117,7 +116,7 @@ M.place_diagnostics = function(bufnr)
   if not state.settings.discussion_signs.enabled then
     return
   end
-  local view = diffview_lib.get_current_view()
+  local view = require("gitlab.reviewer").diffview
   if view == nil then
     u.notify("Could not find Diffview view", vim.log.levels.ERROR)
     return

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -8,6 +8,7 @@ local reviewer = require("gitlab.reviewer")
 local discussions = require("gitlab.actions.discussions")
 local merge_requests = require("gitlab.actions.merge_requests")
 local merge = require("gitlab.actions.merge")
+local rebase = require("gitlab.actions.rebase")
 local summary = require("gitlab.actions.summary")
 local data = require("gitlab.actions.data")
 local assignees_and_reviewers = require("gitlab.actions.assignees_and_reviewers")
@@ -83,11 +84,15 @@ return {
   review = async.sequence({ u.merge(info, { refresh = true }), revisions, user }, function()
     reviewer.open()
   end),
+  reload_review = function()
+    reviewer.reload()
+  end,
   close_review = function()
     reviewer.close()
   end,
   pipeline = async.sequence({ latest_pipeline }, pipeline.open),
   merge = async.sequence({ u.merge(info, { refresh = true }) }, merge.merge),
+  rebase = async.sequence({ u.merge(mergeability, { refresh = true }), info }, rebase.rebase),
   -- Discussion Tree Actions 🌴
   toggle_discussions = function()
     if discussions.split_visible then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -6,15 +6,13 @@
 local List = require("gitlab.utils.list")
 local u = require("gitlab.utils")
 local state = require("gitlab.state")
-local git = require("gitlab.git")
 local hunks = require("gitlab.hunks")
 local async = require("diffview.async")
-local diffview_lib = require("diffview.lib")
 
 local M = {
   is_open = false,
   bufnr = nil,
-  tabnr = nil,
+  tabid = nil,
   stored_win = nil,
   buf_winids = {},
 }
@@ -29,7 +27,7 @@ M.init = function()
   end
 end
 
--- Opens the reviewer window.
+-- Opens the reviewer windows.
 M.open = function()
   local diff_refs = state.INFO.diff_refs
   if diff_refs == nil then
@@ -42,6 +40,9 @@ M.open = function()
     return
   end
 
+  require("gitlab.git_async").check_current_branch_up_to_date_on_remote()
+  local git = require("gitlab.git")
+
   local diffview_open_command = "DiffviewOpen"
 
   if state.settings.reviewer_settings.diffview.imply_local then
@@ -52,10 +53,7 @@ M.open = function()
     if has_clean_tree then
       diffview_open_command = diffview_open_command .. " --imply-local"
     else
-      u.notify(
-        "Your working tree has changes, cannot use 'imply_local' setting for gitlab reviews.\n Stash or commit all changes to use.",
-        vim.log.levels.WARN
-      )
+      u.notify("Working tree unclean. Stash or commit all changes to use 'imply_local'.", vim.log.levels.WARN)
       state.settings.reviewer_settings.diffview.imply_local = false
     end
   end
@@ -63,9 +61,13 @@ M.open = function()
   vim.api.nvim_command(string.format("%s %s..%s", diffview_open_command, diff_refs.base_sha, diff_refs.head_sha))
 
   M.is_open = true
-  local cur_view = diffview_lib.get_current_view()
-  M.diffview_layout = cur_view.cur_layout
-  M.tabnr = vim.api.nvim_get_current_tabpage()
+  M.diffview = require("diffview.lib").get_current_view()
+  if M.diffview == nil then
+    u.notify("Could not find Diffview view", vim.log.levels.ERROR)
+    return
+  end
+  M.diffview_layout = M.diffview.cur_layout
+  M.tabid = vim.api.nvim_get_current_tabpage()
 
   if state.settings.discussion_diagnostic ~= nil or state.settings.discussion_sign ~= nil then
     u.notify(
@@ -76,13 +78,13 @@ M.open = function()
 
   -- Register Diffview hook for close event to set tab page # to nil
   local on_diffview_closed = function(view)
-    if view.tabpage == M.tabnr then
-      M.tabnr = nil
+    if view.tabpage == M.tabid then
+      M.tabid = nil
       require("gitlab.actions.discussions.winbar").cleanup_timer()
     end
   end
   require("diffview.config").user_emitter:on("view_closed", function(_, args)
-    if M.tabnr == args.tabpage then
+    if M.tabid == args.tabpage then
       M.is_open = false
       on_diffview_closed(args)
     end
@@ -94,15 +96,35 @@ M.open = function()
     require("gitlab").toggle_discussions() -- Fetches data and opens discussions
   end
 
-  git.check_current_branch_up_to_date_on_remote(vim.log.levels.WARN)
   git.check_mr_in_good_condition()
 end
 
 -- Closes the reviewer and cleans up
 M.close = function()
-  vim.cmd("DiffviewClose")
+  if M.tabid ~= nil and vim.api.nvim_tabpage_is_valid(M.tabid) then
+    vim.cmd.tabclose(vim.api.nvim_tabpage_get_number(M.tabid))
+  end
   local discussions = require("gitlab.actions.discussions")
   discussions.close()
+end
+
+---Loads new INFO state from Gitlab, then if diffview.api is available applies the new diff refs to
+---the existing diffview, otherwise closes and re-opens the reviewer.
+M.reload = function()
+  state.load_new_state("info", function()
+    state.load_new_state("revisions", function()
+      local has_api, api = pcall(require, "diffview.api")
+      if has_api then
+        api.set_revs(
+          string.format("%s..%s", state.INFO.diff_refs.base_sha, state.INFO.diff_refs.head_sha),
+          { view = M.diffview }
+        )
+      else
+        M.close()
+        M.open()
+      end
+    end)
+  end)
 end
 
 --- Jumps to the location provided in the reviewer window
@@ -114,18 +136,18 @@ M.jump = function(file_name, old_file_name, line_number, new_buffer)
   -- Draft comments don't have `old_file_name` set
   old_file_name = old_file_name or file_name
 
-  if M.tabnr == nil then
+  if M.tabid == nil then
     u.notify("Can't jump to Diffvew. Is it open?", vim.log.levels.ERROR)
     return
   end
-  vim.api.nvim_set_current_tabpage(M.tabnr)
-  local view = diffview_lib.get_current_view()
-  if view == nil then
+  vim.api.nvim_set_current_tabpage(M.tabid)
+
+  if M.diffview == nil then
     u.notify("Could not find Diffview view", vim.log.levels.ERROR)
     return
   end
 
-  local files = view.panel:ordered_file_list()
+  local files = M.diffview.panel:ordered_file_list()
   local file = List.new(files):find(function(f)
     local oldpath = f.oldpath ~= nil and f.oldpath or f.path
     return new_buffer and f.path == file_name or oldpath == old_file_name
@@ -137,9 +159,9 @@ M.jump = function(file_name, old_file_name, line_number, new_buffer)
     )
     return
   end
-  async.await(view:set_file(file))
+  async.await(M.diffview:set_file(file))
 
-  local layout = view.cur_layout
+  local layout = M.diffview.cur_layout
   local number_of_lines
   if new_buffer then
     layout.b:focus()
@@ -162,11 +184,10 @@ end
 ---@param current_win integer The ID of the currently focused window
 ---@return DiffviewInfo | nil
 M.get_reviewer_data = function(current_win)
-  local view = diffview_lib.get_current_view()
-  if view == nil then
+  if M.diffview == nil then
     return
   end
-  local layout = view.cur_layout
+  local layout = M.diffview.cur_layout
   local old_win = u.get_window_id_by_buffer_id(layout.a.file.bufnr)
   local new_win = u.get_window_id_by_buffer_id(layout.b.file.bufnr)
 
@@ -216,8 +237,7 @@ end
 ---@param current_win integer The ID of the currently focused window
 ---@return boolean
 M.is_new_sha_focused = function(current_win)
-  local view = diffview_lib.get_current_view()
-  local layout = view.cur_layout
+  local layout = M.diffview.cur_layout
   local b_win = u.get_window_id_by_buffer_id(layout.b.file.bufnr)
   local a_win = u.get_window_id_by_buffer_id(layout.a.file.bufnr)
   if a_win ~= current_win and b_win ~= current_win then
@@ -229,8 +249,7 @@ end
 
 ---Get currently shown file data
 M.get_current_file_data = function()
-  local view = diffview_lib.get_current_view()
-  return view and view.panel and view.panel.cur_file
+  return M.diffview and M.diffview.panel and M.diffview.panel.cur_file
 end
 
 ---Get currently shown file path
@@ -269,7 +288,7 @@ M.set_callback_for_file_changed = function(callback)
     pattern = { "DiffviewDiffBufWinEnter" },
     group = group,
     callback = function(...)
-      if M.tabnr == vim.api.nvim_get_current_tabpage() then
+      if M.tabid == vim.api.nvim_get_current_tabpage() then
         callback(...)
       end
     end,
@@ -284,7 +303,7 @@ M.set_callback_for_buf_read = function(callback)
     pattern = { "DiffviewDiffBufRead" },
     group = group,
     callback = function(...)
-      if vim.api.nvim_get_current_tabpage() == M.tabnr then
+      if vim.api.nvim_get_current_tabpage() == M.tabid then
         callback(...)
       end
     end,
@@ -299,7 +318,7 @@ M.set_callback_for_reviewer_leave = function(callback)
     pattern = { "DiffviewViewLeave", "DiffviewViewClosed" },
     group = group,
     callback = function(...)
-      if vim.api.nvim_get_current_tabpage() == M.tabnr then
+      if vim.api.nvim_get_current_tabpage() == M.tabid then
         callback(...)
       end
     end,
@@ -315,7 +334,7 @@ M.set_callback_for_reviewer_enter = function(callback)
     pattern = { "DiffviewViewEnter", "DiffviewViewOpened" },
     group = group,
     callback = function(...)
-      if vim.api.nvim_get_current_tabpage() == M.tabnr then
+      if vim.api.nvim_get_current_tabpage() == M.tabid then
         callback(...)
       end
     end,

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -86,9 +86,13 @@ M.settings = {
       revoke = "glR",
       merge = "glM",
       set_auto_merge = "glm",
+      rebase = "glrr",
+      rebase_skip_ci = "glrs",
+      rebase_force = "glrf",
       create_mr = "glC",
       choose_merge_request = "glc",
       start_review = "glS",
+      reload_review = "gl<C-R>",
       summary = "gls",
       copy_mr_url = "glu",
       open_in_browser = "glo",
@@ -200,6 +204,10 @@ M.settings = {
       width = 40,
       border = "rounded",
     },
+  },
+  rebase_mr = {
+    skip_ci = false,
+    force = false,
   },
   choose_merge_request = {
     open_reviewer = true,
@@ -329,6 +337,12 @@ M.set_global_keymaps = function()
     end, { desc = "Start Gitlab review", nowait = keymaps.global.start_review_nowait })
   end
 
+  if keymaps.global.reload_review then
+    vim.keymap.set("n", keymaps.global.reload_review, function()
+      require("gitlab").reload_review()
+    end, { desc = "Reload Gitlab review", nowait = keymaps.global.reload_review_nowait })
+  end
+
   if keymaps.global.choose_merge_request then
     vim.keymap.set("n", keymaps.global.choose_merge_request, function()
       require("gitlab").choose_merge_request()
@@ -429,6 +443,24 @@ M.set_global_keymaps = function()
     vim.keymap.set("n", keymaps.global.set_auto_merge, function()
       require("gitlab").merge({ auto_merge = true })
     end, { desc = "Set MR to auto-merge", nowait = keymaps.global.set_auto_merge_nowait })
+  end
+
+  if keymaps.global.rebase then
+    vim.keymap.set("n", keymaps.global.rebase, function()
+      require("gitlab").rebase()
+    end, { desc = "Rebase MR", nowait = keymaps.global.rebase_nowait })
+  end
+
+  if keymaps.global.rebase_skip_ci then
+    vim.keymap.set("n", keymaps.global.rebase_skip_ci, function()
+      require("gitlab").rebase({ skip_ci = true })
+    end, { desc = "Rebase MR and skip CI", nowait = keymaps.global.rebase_skip_ci_nowait })
+  end
+
+  if keymaps.global.rebase_force then
+    vim.keymap.set("n", keymaps.global.rebase_force, function()
+      require("gitlab").rebase({ force = true })
+    end, { desc = "Force rebase MR", nowait = keymaps.global.rebase_force_nowait })
   end
 
   if keymaps.global.copy_mr_url then


### PR DESCRIPTION
Closes #497.

~This is still in draft because I would like to test it thoroughly, but~ the main functionality works. The maintained Diffview fork supports [updating a diffview](https://github.com/dlyongemallo/diffview.nvim/pull/92), and [programmatically modifying selections](https://github.com/dlyongemallo/diffview.nvim/pull/91) which enables us to update the reviewer in place without closing and reopening after a rebase.

~There will be a trivial conflict with #530 because both PR's add keybindings in the same place in settings.~

I've also replaced some synchronous system calls to `git` with async calls. This prevents blocking the UI (cursor and winbar updates) when checking if the local branch is up-to-date with the remote tracking branch. This makes loading the summary and rebuilding the discussion tree more responsive.

AI use: The Go code is mostly generated by Claude Opus 4.5. The same model has been used for reviewing the lua code.