### PR TITLE
Prevent usage of external diff tools

### DIFF
--- a/lua/gitlab/hunks.lua
+++ b/lua/gitlab/hunks.lua
@@ -102,6 +102,7 @@ local parse_hunks_and_diff = function(base_sha)
     "--minimal",
     "--unified=0",
     "--no-color",
+    "--no-ext-diff",
     base_sha,
     "--",
     reviewer.get_current_file_oldpath(),


### PR DESCRIPTION
Makes `parse_hunks_and_diff` pass `--no-ext-diff` to `git diff` to prevent an external diff tool configured in `~/.gitconfig` clobering the diff output it depends on to parse the hunks.

This resolves some, but likely not all, instances of https://github.com/harrisoncramer/gitlab.nvim/issues/386