### PR TITLE
docs: recommend using dlyongemallo's fork of diffview

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With <a href="https://github.com/folke/lazy.nvim">Lazy</a>:
   dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
-    "sindrets/diffview.nvim",
+    "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
     "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
     "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
   },
@@ -59,7 +59,7 @@ And with <a href="https://github.com/lewis6991/pckr.nvim">pckr.nvim</a>:
   requires = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
-    "sindrets/diffview.nvim",
+    "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
     "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
     "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
   },
@@ -72,6 +72,8 @@ And with <a href="https://github.com/lewis6991/pckr.nvim">pckr.nvim</a>:
 ```
 
 Add `branch = "develop",` to your configuration if you want to use the (possibly unstable) development version of `gitlab.nvim`.
+
+`gitlab.nvim` uses the `diffview.nvim` plugin for showing the diffs in a MR. We recommend using [dlyongemallo's](https://github.com/dlyongemallo/diffview.nvim) fork which is the de-facto maintained version of the plugin with many fixes and improvements (e.g., marking files as viewed).
 
 ## Contributing
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -64,7 +64,7 @@ With Lazy:
       dependencies = {
         "MunifTanjim/nui.nvim",
         "nvim-lua/plenary.nvim",
-        "sindrets/diffview.nvim",
+        "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
         "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
         "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
       },
@@ -81,7 +81,7 @@ And with pckr.nvim:
       requires = {
         "MunifTanjim/nui.nvim",
         "nvim-lua/plenary.nvim",
-        "sindrets/diffview.nvim",
+        "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
         "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
         "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
       },

--- a/lua-test.sh
+++ b/lua-test.sh
@@ -10,7 +10,7 @@ PLUGINS_FOLDER="tests/plugins"
 PLUGINS=(
   "https://github.com/MunifTanjim/nui.nvim"
   "https://github.com/nvim-lua/plenary.nvim"
-  "https://github.com/sindrets/diffview.nvim"
+  "https://github.com/dlyongemallo/diffview.nvim"
 )
 
 if ! command -v luarocks >/dev/null 2>&1; then

--- a/lua/gitlab/health.lua
+++ b/lua/gitlab/health.lua
@@ -31,7 +31,7 @@ M.check = function(return_results)
       package = "plenary",
     },
     {
-      name = "sindrets/diffview.nvim",
+      name = "dlyongemallo/diffview.nvim",
       package = "diffview",
     },
   }


### PR DESCRIPTION
[dlyongemallo's](https://github.com/dlyongemallo/diffview.nvim) fork is the de-facto maintained version of the plugin with many fixes and improvements (e.g., marking files as viewed), we should recommend using it over the original plugin.

I'm planning to use functionality implemented in dlyongemallo's fork in #534 (I'll make it compatible with the [original plugin](https://github.com/sindrets/diffview.nvim), though.