### PR TITLE
fix: add SECURITY_POLICY_PIPELINE_CHECK mergeability identifier

### DIFF
--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -346,6 +346,7 @@ you call this function with no values the defaults will be used:
             NOT_APPROVED = "All required approvals must be given",
             NOT_OPEN = "Merge request must be open",
             REQUESTED_CHANGES = "Change requests must be approved by the requesting user",
+            SECURITY_POLICY_PIPELINE_CHECK = "Security policy pipeline must succeed",
             SECURITY_POLICY_VIOLATIONS = "Security policies are satisfied",
             STATUS_CHECKS_MUST_PASS = "External status checks pass",
             TITLE_REGEX = "Title matches the expected regex",

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -287,6 +287,7 @@
 ---@field NOT_APPROVED string|false
 ---@field NOT_OPEN string|false
 ---@field REQUESTED_CHANGES string|false
+---@field SECURITY_POLICY_PIPELINE_CHECK string|false
 ---@field SECURITY_POLICY_VIOLATIONS string|false
 ---@field STATUS_CHECKS_MUST_PASS string|false
 ---@field TITLE_REGEX string|false

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -250,6 +250,7 @@ M.settings = {
       NOT_APPROVED = "All required approvals must be given",
       NOT_OPEN = "Merge request must be open",
       REQUESTED_CHANGES = "Change requests must be approved by the requesting user",
+      SECURITY_POLICY_PIPELINE_CHECK = "Security policy pipeline must succeed",
       SECURITY_POLICY_VIOLATIONS = "Security policies are satisfied",
       STATUS_CHECKS_MUST_PASS = "External status checks pass",
       TITLE_REGEX = "Title matches the expected regex",


### PR DESCRIPTION
## Summary

- GitLab's API can return `SECURITY_POLICY_PIPELINE_CHECK` as a mergeability check identifier, but it wasn't in the known checks list, causing an "Unknown mergeability check identifier" error in the summary view.

## Test plan

- Open a project with security policy pipeline checks enabled
- Run `gls` to open summary
- Verify no "Unknown mergeability check identifier" error appears