### PR TITLE
fix(proxy): bypass proxy for localhost requests to Go server

### DIFF
--- a/lua/gitlab/job.lua
+++ b/lua/gitlab/job.lua
@@ -7,7 +7,7 @@ local M = {}
 M.run_job = function(endpoint, method, body, callback, on_error_callback)
   local state = require("gitlab.state")
   local port = state.settings.server and state.settings.server.port
-  local args = { "-s", "-X", (method or "POST"), string.format("localhost:%s%s", port, endpoint) }
+  local args = { "--noproxy", "localhost", "-s", "-X", (method or "POST"), string.format("localhost:%s%s", port, endpoint) }
 
   if body ~= nil then
     local encoded_body = vim.json.encode(body)

--- a/lua/gitlab/job.lua
+++ b/lua/gitlab/job.lua
@@ -7,7 +7,8 @@ local M = {}
 M.run_job = function(endpoint, method, body, callback, on_error_callback)
   local state = require("gitlab.state")
   local port = state.settings.server and state.settings.server.port
-  local args = { "--noproxy", "localhost", "-s", "-X", (method or "POST"), string.format("localhost:%s%s", port, endpoint) }
+  local args =
+    { "--noproxy", "localhost", "-s", "-X", (method or "POST"), string.format("localhost:%s%s", port, endpoint) }
 
   if body ~= nil then
     local encoded_body = vim.json.encode(body)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -240,7 +240,8 @@ M.get_version = function(callback)
   local version_output = vim.system({ "git", "describe", "--tags", "--always" }, { cwd = parent_dir }):wait()
   local plugin_version = version_output.code == 0 and vim.trim(version_output.stdout) or "unknown"
 
-  local args = { "--noproxy", "localhost", "-s", "-X", "GET", string.format("localhost:%s/version", state.settings.server.port) }
+  local args =
+    { "--noproxy", "localhost", "-s", "-X", "GET", string.format("localhost:%s/version", state.settings.server.port) }
 
   -- We call the "/version" endpoint here instead of through the regular jobs pattern because earlier versions of the plugin
   -- may not have it. We handle a 404 as an "unknown" version error.

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -240,7 +240,7 @@ M.get_version = function(callback)
   local version_output = vim.system({ "git", "describe", "--tags", "--always" }, { cwd = parent_dir }):wait()
   local plugin_version = version_output.code == 0 and vim.trim(version_output.stdout) or "unknown"
 
-  local args = { "-s", "-X", "GET", string.format("localhost:%s/version", state.settings.server.port) }
+  local args = { "--noproxy", "localhost", "-s", "-X", "GET", string.format("localhost:%s/version", state.settings.server.port) }
 
   -- We call the "/version" endpoint here instead of through the regular jobs pattern because earlier versions of the plugin
   -- may not have it. We handle a 404 as an "unknown" version error.


### PR DESCRIPTION
## Summary
- Adds `--noproxy localhost` to all curl calls from the Lua plugin to the local Go server
- When users have a proxy configured (either via `connection_settings.proxy` or system env vars like `HTTP_PROXY`), curl was routing localhost requests through the proxy, causing connection failures
- Fixes #537