### PR TITLE
feat: add non_blocking support for async fetch dependencies

### DIFF
--- a/lua/gitlab/async.lua
+++ b/lua/gitlab/async.lua
@@ -37,10 +37,16 @@ function async:fetch(dependencies, i, argTable)
 
   -- Call the API, set the data, and then call the next API
   local body = dependency.body and dependency.body(argTable) or nil
+  local on_error = nil
+  if dependency.non_blocking then
+    on_error = function()
+      self:fetch(dependencies, i + 1, argTable)
+    end
+  end
   job.run_job(dependency.endpoint, dependency.method or "GET", body, function(data)
     state[dependency.state] = dependency.key and data[dependency.key] or data
     self:fetch(dependencies, i + 1, argTable)
-  end)
+  end, on_error)
 end
 
 -- Will call APIs in sequence and set global state

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -538,6 +538,7 @@ M.dependencies = {
     key = "draft_notes",
     state = "DRAFT_NOTES",
     refresh = false,
+    non_blocking = true,
   },
   project_members = {
     endpoint = "/project/members",


### PR DESCRIPTION
## Summary

This MR adds `non_blocking` support to the async fetch pipeline, allowing certain API dependencies to continue fetching subsequent dependencies even if they fail. The `draft_notes` dependency is marked as non-blocking.
Perhaps none should be blocking or even fetch in parallel?

## Problem

When fetching `draft_notes` fails (e.g., due to permissions or unsupported GitLab editions), it blocks the entire async dependency chain, preventing all subsequent API calls from completing. This can break the plugin for users whose GitLab instance doesn't support draft notes, and as consequence preventing them to see and toggle the comments section.

## Changes

- **`lua/gitlab/async.lua`**: Added `non_blocking` logic — when a dependency is marked `non_blocking`, an `on_error` callback is created that continues fetching the next dependency instead of halting the chain. This callback is passed to `job.run_job`.
- **`lua/gitlab/state.lua`**: Set `non_blocking = true` on the `draft_notes` dependency so its failure doesn't block the remaining fetches.
