### PR TITLE
fix(build): allow force-rebuilding server binary

### DIFF
--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -122,8 +122,7 @@ M.build = function(override)
   state.settings.root_path = u.get_root_path()
 
   -- If the user provided a path to the server, don't build it.
-  if state.settings.server.binary ~= nil then
-    state.settings.server.binary_provided = true
+  if state.settings.server.binary_provided then
     local binary_exists = vim.loop.fs_stat(state.settings.server.binary)
     if binary_exists == nil then
       u.notify(

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -454,6 +454,9 @@ end
 ---@param args Settings
 ---@return Settings
 M.merge_settings = function(args)
+  if args.server and args.server.binary ~= nil then
+    M.settings.server.binary_provided = true
+  end
   M.settings = u.merge(M.settings, args)
   return M.settings
 end


### PR DESCRIPTION
## Summary

- Fixes the `build(true)` force-rebuild not working after the initial build
- The `server.binary` field was being set during the first build, causing subsequent calls to think it was a user-provided path and skip rebuilding
- Now tracks user-provided binaries via a `binary_provided` flag set during config merge

Closes #545