### PR TITLE
feat: Fetch all merge request beyond the default 20

### DIFF
--- a/cmd/app/merge_requests.go
+++ b/cmd/app/merge_requests.go
@@ -35,16 +35,23 @@ func (a mergeRequestListerService) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		payload.Scope = gitlab.Ptr("all")
 	}
 
-	mergeRequests, res, err := a.client.ListProjectMergeRequests(a.projectInfo.ProjectId, payload)
+	payload.PerPage = 100
+	var mergeRequests []*gitlab.BasicMergeRequest
+	for nextPage := int64(1); nextPage != 0; {
+		payload.Page = nextPage
+		mrs, res, err := a.client.ListProjectMergeRequests(a.projectInfo.ProjectId, payload)
+		if err != nil {
+			handleError(w, err, "Failed to list merge requests", http.StatusInternalServerError)
+			return
+		}
 
-	if err != nil {
-		handleError(w, err, "Failed to list merge requests", http.StatusInternalServerError)
-		return
-	}
+		if res.StatusCode >= 300 {
+			handleError(w, GenericError{r.URL.Path}, "Failed to list merge requests", res.StatusCode)
+			return
+		}
 
-	if res.StatusCode >= 300 {
-		handleError(w, GenericError{r.URL.Path}, "Failed to list merge requests", res.StatusCode)
-		return
+		mergeRequests = append(mergeRequests, mrs...)
+		nextPage = res.NextPage
 	}
 
 	if len(mergeRequests) == 0 {
@@ -58,7 +65,7 @@ func (a mergeRequestListerService) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		MergeRequests:   mergeRequests,
 	}
 
-	err = json.NewEncoder(w).Encode(response)
+	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		handleError(w, err, "could not encode response", http.StatusInternalServerError)
 	}

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -256,6 +256,7 @@
 
 ---@class ChooseMergeRequestSettings
 ---@field open_reviewer? boolean -- Open the reviewer window automatically after switching merge requests
+---@field per_page? integer -- Number of merge requests to fetch (default: 100)
 
 ---@class InfoSettings
 ---@field horizontal? boolean -- Display metadata to the left of the summary rather than underneath

--- a/lua/gitlab/annotations.lua
+++ b/lua/gitlab/annotations.lua
@@ -256,7 +256,6 @@
 
 ---@class ChooseMergeRequestSettings
 ---@field open_reviewer? boolean -- Open the reviewer window automatically after switching merge requests
----@field per_page? integer -- Number of merge requests to fetch (default: 100)
 
 ---@class InfoSettings
 ---@field horizontal? boolean -- Display metadata to the left of the summary rather than underneath

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -203,7 +203,6 @@ M.settings = {
   },
   choose_merge_request = {
     open_reviewer = true,
-    per_page = 100,
   },
   info = {
     enabled = true,
@@ -560,11 +559,7 @@ M.dependencies = {
         opts["not[label]"] = opts.notlabel
         opts.notlabel = nil
       end
-      local body = opts or {}
-      if body.per_page == nil then
-        body.per_page = M.settings.choose_merge_request.per_page
-      end
-      return body
+      return opts or {}
     end,
   },
   merge_requests_by_username = {

--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -203,6 +203,7 @@ M.settings = {
   },
   choose_merge_request = {
     open_reviewer = true,
+    per_page = 100,
   },
   info = {
     enabled = true,
@@ -559,7 +560,11 @@ M.dependencies = {
         opts["not[label]"] = opts.notlabel
         opts.notlabel = nil
       end
-      return opts or vim.json.decode("{}")
+      local body = opts or {}
+      if body.per_page == nil then
+        body.per_page = M.settings.choose_merge_request.per_page
+      end
+      return body
     end,
   },
   merge_requests_by_username = {


### PR DESCRIPTION
**Summary**

Fetch all project merge requests from the GitLab API by paginating through results server-side, instead of relying on a single page (default 20). This ensures the merge request chooser shows the complete list regardless of project size.

**Problem**

The `ListProjectMergeRequests` call only returned the first page of results (default 20 MRs per the GitLab API). Projects with more merge requests had entries silently truncated, so users could not select older or less recent MRs from the picker. An earlier attempt added a `per_page` option on the Lua side, but that only shifted the limit instead of solving the truncation.

**Changes**

- `cmd/app/merge_requests.go`: loop over all pages using `res.NextPage`, accumulating results into a single `mergeRequests` slice before responding.
- Default `PerPage` to 100, to minimize round-trips.