### PR TITLE
fix: encode empty merge_requests body as JSON object instead of array

### DIFF
--- a/lua/gitlab/state.lua
+++ b/lua/gitlab/state.lua
@@ -562,7 +562,7 @@ M.dependencies = {
         opts["not[label]"] = opts.notlabel
         opts.notlabel = nil
       end
-      return opts or {}
+      return opts or vim.empty_dict()
     end,
   },
   merge_requests_by_username = {


### PR DESCRIPTION
When choose_merge_request() is called without arguments, the body function returns an empty Lua table {} which vim.json.encode serializes as a JSON array []. The Go server expects a JSON object and fails with: 'cannot unmarshal array into Go value of type ListProjectMergeRequestsOptions'

Using vim.empty_dict() ensures the empty table is encoded as {} instead.