### PR TITLE
fix(git): handle detached HEAD silently

### DIFF
--- a/lua/gitlab/git.lua
+++ b/lua/gitlab/git.lua
@@ -104,12 +104,16 @@ M.get_ahead_behind = function(current_branch, remote_branch)
   return tonumber(ahead), tonumber(behind)
 end
 
----Return the name of the current branch or nil if it can't be retrieved
+---Return the name of the current branch, or nil (detached HEAD or git failure).
 ---@return string|nil
 M.get_current_branch = function()
   local current_branch, err = run_system({ "git", "branch", "--show-current" })
-  if err or current_branch == "" then
+  if err then
     require("gitlab.utils").notify("Could not get current branch: " .. err, vim.log.levels.ERROR)
+    return nil
+  end
+  if current_branch == "" then
+    -- detached HEAD: `git branch --show-current` returns empty + exit 0
     return nil
   end
   return current_branch


### PR DESCRIPTION
Closes #555.

`git branch --show-current` returns an empty string with exit code 0 when HEAD is detached or the repo has no commits. That's a valid state, not an error. The old code routed it through the error branch anyway, so the operation was cancelled with an error message instead of proceeding.

The fix splits the two cases. In detached HEAD, the picker now proceeds with the check-out (the caller in `merge_requests.lua:33` already handles nil). Real git failures still notify ERROR.