### PR TITLE
fix(server): use vim.system instead of jobstart to bypass shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To view these help docs and to get more detailed help information, please run `:
 
 ## Requirements
 
+- <a href="https://neovim.io/">Neovim</a> >= v0.10
 - <a href="https://go.dev/">Go</a> >= v1.25.1
 
 ## Quick Start

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -62,6 +62,8 @@ M.start = function(callback)
 
   local settings = vim.json.encode(go_server_settings)
 
+  local stderr_buf = ""
+
   local ok, err = pcall(vim.system, { state.settings.server.binary, settings }, {
     stdout = function(_, data)
       if data == nil or parsed_port ~= nil then
@@ -87,17 +89,16 @@ M.start = function(callback)
       if data == nil or data == "" then
         return
       end
-      vim.schedule(function()
-        u.notify(data, vim.log.levels.ERROR)
-      end)
+      stderr_buf = stderr_buf .. data
     end,
   }, function(out)
     if out.code ~= 0 then
       vim.schedule(function()
-        u.notify(
-          "Golang gitlab server exited: code: " .. out.code .. ", signal: " .. (out.signal or 0),
-          vim.log.levels.ERROR
-        )
+        local msg = "Golang gitlab server exited: code: " .. out.code .. ", signal: " .. (out.signal or 0)
+        if stderr_buf ~= "" then
+          msg = msg .. ", msg: " .. stderr_buf
+        end
+        u.notify(msg, vim.log.levels.ERROR)
       end)
     end
   end)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -62,13 +62,8 @@ M.start = function(callback)
   state.chosen_mr_iid = 0 -- Do not let this interfere with subsequent reviewer.open() calls
 
   local settings = vim.json.encode(go_server_settings)
-  if vim.fn.has("win32") then
-    settings = settings:gsub('"', '\\"')
-  end
 
-  local command = string.format('"%s" "%s"', state.settings.server.binary, settings)
-
-  local job_id = vim.fn.jobstart(command, {
+  local job_id = vim.fn.jobstart({ state.settings.server.binary, settings }, {
     on_stdout = function(_, data)
       -- if port was not provided then we need to parse it from output of server
       if parsed_port == nil then

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -96,7 +96,7 @@ M.start = function(callback)
       vim.schedule(function()
         local msg = "Golang gitlab server exited: code: " .. out.code .. ", signal: " .. (out.signal or 0)
         if stderr_buf ~= "" then
-          msg = msg .. ", msg: " .. stderr_buf
+          msg = msg .. ", msg: " .. vim.trim(stderr_buf)
         end
         u.notify(msg, vim.log.levels.ERROR)
       end)

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -1,7 +1,6 @@
 -- This module contains the logic responsible for building and starting
 -- the Golang server. The Go server is responsible for making API calls
 -- to Gitlab and returning the data
-local List = require("gitlab.utils.list")
 local state = require("gitlab.state")
 local u = require("gitlab.utils")
 local job = require("gitlab.job")
@@ -63,52 +62,48 @@ M.start = function(callback)
 
   local settings = vim.json.encode(go_server_settings)
 
-  local job_id = vim.fn.jobstart({ state.settings.server.binary, settings }, {
-    on_stdout = function(_, data)
-      -- if port was not provided then we need to parse it from output of server
-      if parsed_port == nil then
-        for _, line in ipairs(data) do
-          port = line:match("Server started on port:%s+(%d+)")
-          if port ~= nil then
-            parsed_port = port
-            state.settings.server.port = port
-            break
-          end
+  local ok, err = pcall(vim.system, { state.settings.server.binary, settings }, {
+    stdout = function(_, data)
+      if data == nil or parsed_port ~= nil then
+        return
+      end
+      for line in data:gmatch("[^\r\n]+") do
+        local matched = line:match("Server started on port:%s+(%d+)")
+        if matched ~= nil then
+          parsed_port = matched
+          vim.schedule(function()
+            state.settings.server.port = matched
+            state.go_server_running = true
+            if not callback_called then
+              callback_called = true
+              callback()
+            end
+          end)
+          break
         end
       end
-
-      -- This assumes that first output of server will be parsable and port will be correctly set.
-      -- Make sure that this actually check if port was correctly parsed based on server output
-      -- because server outputs port only if it started successfully.
-      if parsed_port ~= nil and not callback_called then
-        state.go_server_running = true
-        callback()
-        callback_called = true
-      end
     end,
-    on_stderr = function(_, errors)
-      local err_msg = List.new(errors):reduce(function(agg, err)
-        if err ~= "" and err ~= nil then
-          agg = agg .. err .. "\n"
-        end
-        return agg
-      end, "")
-
-      if err_msg ~= "" then
-        u.notify(err_msg, vim.log.levels.ERROR)
+    stderr = function(_, data)
+      if data == nil or data == "" then
+        return
       end
+      vim.schedule(function()
+        u.notify(data, vim.log.levels.ERROR)
+      end)
     end,
-    on_exit = function(job_id, exit_code)
-      if exit_code ~= 0 then
+  }, function(out)
+    if out.code ~= 0 then
+      vim.schedule(function()
         u.notify(
-          "Golang gitlab server exited: job_id: " .. job_id .. ", exit_code: " .. exit_code,
+          "Golang gitlab server exited: code: " .. out.code .. ", signal: " .. (out.signal or 0),
           vim.log.levels.ERROR
         )
-      end
-    end,
-  })
-  if job_id <= 0 then
-    u.notify("Could not start gitlab.nvim binary", vim.log.levels.ERROR)
+      end)
+    end
+  end)
+
+  if not ok then
+    u.notify("Could not start gitlab.nvim binary: " .. tostring(err), vim.log.levels.ERROR)
   end
 end
 


### PR DESCRIPTION
## Summary
Switch the server launch from `vim.fn.jobstart` to `vim.system`, passing the binary and JSON settings as a list. Neovim spawns the process directly instead of going through the user's shell, removing the Windows-specific `"`-escaping hack that only worked for POSIX-style shells.

## Why
On Windows with a non-POSIX shell (e.g. Nushell) the previous string-form `jobstart` call was passed through `&shell &shellcmdflag`, and the quoting/escaping assumptions broke, preventing the Go server from starting. `vim.system` skips the shell entirely, so argument boundaries and JSON quoting are preserved verbatim regardless of shell.

## Test plan
- [x] Start the plugin on Windows with `shell=nu` and confirm the server launches
- [x] Start the plugin on Windows with default cmd.exe/PowerShell
- [ ] Start the plugin on Linux/macOS to confirm no regression