### PR TITLE
docs: use correct type annotations for optional parameters

### DIFF
--- a/lua/gitlab/actions/common.lua
+++ b/lua/gitlab/actions/common.lua
@@ -127,7 +127,7 @@ M.print_node = function(tree)
 end
 
 ---Check if type of node is note or note body
----@param node NuiTree.Node?
+---@param node? NuiTree.Node
 ---@return boolean
 M.is_node_note = function(node)
   if node and (node.type == "note_body" or node.type == "note") then
@@ -139,7 +139,7 @@ end
 
 ---Get root node
 ---@param tree NuiTree
----@param node NuiTree.Node?
+---@param node? NuiTree.Node
 ---@return NuiTree.Node?
 M.get_root_node = function(tree, node)
   if not node then
@@ -155,7 +155,7 @@ end
 
 ---Get note node
 ---@param tree NuiTree
----@param node NuiTree.Node?
+---@param node? NuiTree.Node
 ---@return NuiTree.Node?
 M.get_note_node = function(tree, node)
   if not node then

--- a/lua/gitlab/actions/discussions/init.lua
+++ b/lua/gitlab/actions/discussions/init.lua
@@ -104,7 +104,7 @@ end
 
 ---Opens the discussion tree, sets the keybindings. It also
 ---creates the tree for notes (which are not linked to specific lines of code)
----@param callback function?
+---@param callback? function
 ---@param view_type "discussions"|"notes" Defines the view type to select (useful for overriding the default view type when jumping to discussion tree when it's closed).
 M.open = function(callback, view_type)
   view_type = view_type and view_type or state.settings.discussion_tree.default_view

--- a/lua/gitlab/actions/discussions/tree.lua
+++ b/lua/gitlab/actions/discussions/tree.lua
@@ -11,7 +11,7 @@ local M = {}
 
 ---Create nodes for NuiTree from discussions
 ---@param items Discussion[]
----@param unlinked boolean? False or nil means that discussions are linked to code lines
+---@param unlinked? boolean False or nil means that discussions are linked to code lines
 ---@return NuiTree.Node[]
 M.add_discussions_to_table = function(items, unlinked)
   local t = {}
@@ -102,7 +102,7 @@ end
 ---Create path node
 ---@param relative_path string
 ---@param full_path string
----@param child_nodes NuiTree.Node[]?
+---@param child_nodes? NuiTree.Node[]
 ---@return NuiTree.Node
 local function create_path_node(relative_path, full_path, child_nodes)
   return NuiTree.Node({
@@ -154,7 +154,7 @@ end
 ---Create file name node
 ---@param file_name string
 ---@param full_file_path string
----@param child_nodes NuiTree.Node[]?
+---@param child_nodes? NuiTree.Node[]
 ---@return NuiTree.Node
 local function create_file_name_node(file_name, full_file_path, child_nodes)
   local icon, icon_hl = u.get_icon(file_name)
@@ -262,7 +262,7 @@ end
 
 ---Build note node body
 ---@param note Note|DraftNote
----@param resolve_info table?
+---@param resolve_info? table
 ---@return string
 ---@return NuiTree.Node[]
 local function build_note_body(note, resolve_info)
@@ -297,7 +297,7 @@ end
 
 ---Build note node
 ---@param note Note|DraftNote
----@param resolve_info table?
+---@param resolve_info? table
 ---@return NuiTree.Node
 ---@return string
 ---@return NuiTree.Node[]

--- a/lua/gitlab/actions/merge.lua
+++ b/lua/gitlab/actions/merge.lua
@@ -46,7 +46,7 @@ M.merge = function(opts)
 end
 
 ---@param merge_body MergeOpts
----@param squash_message string?
+---@param squash_message? string
 M.confirm_merge = function(merge_body, squash_message)
   if squash_message ~= nil then
     merge_body.squash_message = squash_message

--- a/lua/gitlab/indicators/diagnostics.lua
+++ b/lua/gitlab/indicators/diagnostics.lua
@@ -89,7 +89,7 @@ end
 ---@param namespace number namespace for diagnostics
 ---@param bufnr number the bufnr for placing the diagnostics
 ---@param diagnostics table see :h vim.diagnostic.set
----@param opts table? see :h vim.diagnostic.set
+---@param opts? table see :h vim.diagnostic.set
 local set_diagnostics = function(namespace, bufnr, diagnostics, opts)
   vim.diagnostic.set(namespace, bufnr, diagnostics, opts)
   require("gitlab.indicators.signs").set_signs(diagnostics, bufnr)

--- a/lua/gitlab/popup.lua
+++ b/lua/gitlab/popup.lua
@@ -5,9 +5,9 @@ local M = {}
 ---Get the popup view_opts
 ---@param title string The string to appear on top of the popup
 ---@param user_settings table|nil User-defined popup settings
----@param width number? Override default width
----@param height number? Override default height
----@param zindex number? Override default zindex
+---@param width? number Override default width
+---@param height? number Override default height
+---@param zindex? number Override default zindex
 ---@return table
 M.create_popup_state = function(title, user_settings, width, height, zindex)
   local settings = u.merge(require("gitlab.state").settings.popup, user_settings or {})

--- a/lua/gitlab/utils/init.lua
+++ b/lua/gitlab/utils/init.lua
@@ -663,7 +663,7 @@ M.get_web_url = function()
   M.notify("Could not get Gitlab URL", vim.log.levels.ERROR)
 end
 
----@param url string?
+---@param url? string
 M.open_in_browser = function(url)
   if vim.fn.has("mac") == 1 then
     vim.fn.jobstart({ "open", url })


### PR DESCRIPTION
This PR fixes type annotations of optional parameters for multiple functions.