### PR TITLE
docs: update references to diffview-plus.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ With <a href="https://github.com/folke/lazy.nvim">Lazy</a>:
   dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
-    "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
+    "dlyongemallo/diffview-plus.nvim", -- Maintained fork of "sindrets/diffview.nvim".
     "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
     "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
   },
@@ -60,7 +60,7 @@ And with <a href="https://github.com/lewis6991/pckr.nvim">pckr.nvim</a>:
   requires = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
-    "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
+    "dlyongemallo/diffview-plus.nvim", -- Maintained fork of "sindrets/diffview.nvim".
     "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
     "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
   },
@@ -74,7 +74,7 @@ And with <a href="https://github.com/lewis6991/pckr.nvim">pckr.nvim</a>:
 
 Add `branch = "develop",` to your configuration if you want to use the (possibly unstable) development version of `gitlab.nvim`.
 
-`gitlab.nvim` uses the `diffview.nvim` plugin for showing the diffs in a MR. We recommend using [dlyongemallo's](https://github.com/dlyongemallo/diffview.nvim) fork which is the de-facto maintained version of the plugin with many fixes and improvements (e.g., marking files as viewed).
+`gitlab.nvim` uses the `diffview.nvim` plugin for showing the diffs in a MR. We recommend using `dlyongemallo`'s [diffview+](https://github.com/dlyongemallo/diffview-plus.nvim) fork which is the de-facto maintained version of the plugin with many fixes and improvements (e.g., marking files as viewed). The original [sindrets/diffview.nvim](https://github.com/sindrets/diffview.nvim) plugin will be supported as long as the maintenance remains feasible.
 
 ## Contributing
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -64,7 +64,7 @@ With Lazy:
       dependencies = {
         "MunifTanjim/nui.nvim",
         "nvim-lua/plenary.nvim",
-        "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
+        "dlyongemallo/diffview-plus.nvim", -- Maintained fork of "sindrets/diffview.nvim".
         "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
         "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
       },
@@ -81,7 +81,7 @@ And with pckr.nvim:
       requires = {
         "MunifTanjim/nui.nvim",
         "nvim-lua/plenary.nvim",
-        "dlyongemallo/diffview.nvim", -- Maintained fork of "sindrets/diffview.nvim".
+        "dlyongemallo/diffview-plus.nvim", -- Maintained fork of "sindrets/diffview.nvim".
         "stevearc/dressing.nvim", -- Recommended but not required. Better UI for pickers.
         "nvim-tree/nvim-web-devicons", -- Recommended but not required. Icons in discussion tree.
       },
@@ -864,9 +864,9 @@ plugin is loaded. If run twice, will open a second reviewer pane.
                                                                 *gitlab.nvim.reload_review*
 gitlab.reload_review() ~
 
-Loads new MR state from Gitlab. Then if diffview.api is available (with the
-https://github.com/dlyongemallo/diffview.nvim fork) applies the new diff refs
-to the existing diffview, otherwise (with
+Loads new MR state from Gitlab. Then if `diffview.api` is available (with the
+https://github.com/dlyongemallo/diffview-plus.nvim fork) applies the new diff
+refs to the existing diffview, otherwise (with
 https://github.com/sindrets/diffview.nvim) closes and re-opens the reviewer.
 
 >lua

--- a/lua-test.sh
+++ b/lua-test.sh
@@ -10,7 +10,7 @@ PLUGINS_FOLDER="tests/plugins"
 PLUGINS=(
   "https://github.com/MunifTanjim/nui.nvim"
   "https://github.com/nvim-lua/plenary.nvim"
-  "https://github.com/dlyongemallo/diffview.nvim"
+  "https://github.com/dlyongemallo/diffview-plus.nvim"
 )
 
 if ! command -v luarocks >/dev/null 2>&1; then

--- a/lua/gitlab/health.lua
+++ b/lua/gitlab/health.lua
@@ -31,7 +31,7 @@ M.check = function(return_results)
       package = "plenary",
     },
     {
-      name = "dlyongemallo/diffview.nvim",
+      name = "dlyongemallo/diffview-plus.nvim",
       package = "diffview",
     },
   }
@@ -44,6 +44,10 @@ M.check = function(return_results)
     {
       name = "nvim-tree/nvim-web-devicons",
       package = "nvim-web-devicons",
+    },
+    {
+      name = "dlyongemallo/diffview-plus.nvim",
+      package = "diffview.api",
     },
   }
 


### PR DESCRIPTION
Document that `dlyongemallo`'s fork has been renamed.

Also, add a health check that verifies if the recommended (but not required) `diffview.api` package is present.