### PR TITLE
docs: add missing dependencies and unify quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,18 @@ To view these help docs and to get more detailed help information, please run `:
 
 ## Requirements
 
-- <a href="https://neovim.io/">Neovim</a> >= v0.10
-- <a href="https://go.dev/">Go</a> >= v1.25.1
+- <a href="https://neovim.io">Neovim</a> >= v0.10
+- <a href="https://go.dev">Go</a> >= v1.25.1
+- <a href="https://git-scm.com">Git</a>
+- <a href="https://curl.se">Curl</a>
+- <a href="https://man.cat-v.org/unix-1st/1/cat">Cat</a> (for displaying pipeline logs)
 
 ## Quick Start
 
-1. Install Go
-2. Add configuration (see Installation section)
-3. Run `:lua require("gitlab").choose_merge_request()` or `:lua require("gitlab").review()` if already in review branch/worktree.
+1. Install the required dependencies
+2. Add configuration (see [Installation](#installation) section)
+3. Open Neovim
+4. Run `:lua require("gitlab").choose_merge_request()` or `:lua require("gitlab").review()` if already in review branch/worktree.
 
 This will checkout the branch locally, and open the plugin's reviewer pane.
 

--- a/doc/gitlab.nvim.txt
+++ b/doc/gitlab.nvim.txt
@@ -44,16 +44,22 @@ the editor. This means you can do things like:
 
 REQUIREMENTS                                        *gitlab.nvim.requirements*
 
-- Go >= v1.19
+- Neovim >= v0.10
+- Go >= v1.25.1
+- Git
+- Curl
+- Cat (for displaying pipeline logs)
 
 
 QUICK START                                          *gitlab.nvim.quick-start*
 
-1. Install Go
-2. Add configuration (see Installation section)
-5. Run `:lua require("gitlab").choose_merge_request()`
+1. Install the required dependencies
+2. Add configuration (see |gitlab.nvim.installation| section)
+3. Open Neovim
+4. Run `:lua require("gitlab").choose_merge_request()` or
+   `:lua require("gitlab").review()` if already in review branch/worktree.
 
-This will checkout the branch locally, and up the plugin's reviewer pane.
+This will checkout the branch locally, and open the plugin's reviewer pane.
 
 INSTALLATION                                        *gitlab.nvim.installation*
 


### PR DESCRIPTION
Add missing dependencies to the Requirements sections in README and doc/gitlab.nvim.