### PR TITLE
fix: only initialize emojis when starting a review

### DIFF
--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -2,7 +2,6 @@ require("gitlab.utils.list")
 local u = require("gitlab.utils")
 local async = require("gitlab.async")
 local server = require("gitlab.server")
-local emoji = require("gitlab.emoji")
 local state = require("gitlab.state")
 local reviewer = require("gitlab.reviewer")
 local discussions = require("gitlab.actions.discussions")
@@ -45,13 +44,11 @@ local function setup(args)
   end
 
   state.merge_settings(args) -- Merges user settings with default settings
-  state.set_plugin_configuration() -- Sets auth_token and gitlab_url into the settings module
   server.build() -- Builds the Go binary if it doesn't exist
   state.set_global_keymaps() -- Sets keymaps that are not bound to a specific buffer
   require("gitlab.colors") -- Sets colors
   reviewer.init()
   discussions.initialize_discussions() -- place signs / diagnostics for discussions in reviewer
-  emoji.init() -- Read in emojis for lookup purposes
 
   local is_healthy = health.check(true)
   if not is_healthy then

--- a/lua/gitlab/reviewer/init.lua
+++ b/lua/gitlab/reviewer/init.lua
@@ -29,6 +29,7 @@ end
 
 -- Opens the reviewer windows.
 M.open = function()
+  require("gitlab.emoji").init() -- Read in emojis for lookup purposes
   local diff_refs = state.INFO.diff_refs
   if diff_refs == nil then
     u.notify("Gitlab did not provide diff refs required to review this MR", vim.log.levels.ERROR)


### PR DESCRIPTION
Initializing plugin configuration during setup caused errors when outside of a git repository. Defer emoji.init (and the required plugin configuration) to when a review is started.