### PR TITLE
fix: only check Go version when building the server

### DIFF
--- a/lua/gitlab/health.lua
+++ b/lua/gitlab/health.lua
@@ -47,9 +47,19 @@ M.check = function(return_results)
     },
   }
 
-  local go_version_problem = version.check_go_version()
-  if go_version_problem ~= nil then
-    table.insert(warnings, go_version_problem)
+  if state.settings.server.binary_provided then
+    local binary_exists = vim.loop.fs_stat(state.settings.server.binary)
+    if binary_exists == nil then
+      table.insert(
+        errors,
+        string.format("The user-provided server path (%s) does not exist", state.settings.server.binary)
+      )
+    end
+  else
+    local go_version_problem = version.check_go_version()
+    if go_version_problem ~= nil then
+      table.insert(errors, go_version_problem)
+    end
   end
 
   for _, dep in ipairs(required_deps) do

--- a/lua/gitlab/init.lua
+++ b/lua/gitlab/init.lua
@@ -12,7 +12,6 @@ local summary = require("gitlab.actions.summary")
 local data = require("gitlab.actions.data")
 local assignees_and_reviewers = require("gitlab.actions.assignees_and_reviewers")
 local comment = require("gitlab.actions.comment")
-local version = require("gitlab.version")
 local pipeline = require("gitlab.actions.pipeline")
 local create_mr = require("gitlab.actions.create_mr")
 local approvals = require("gitlab.actions.approvals")
@@ -35,12 +34,6 @@ local merge_requests_by_username_dep = state.dependencies.merge_requests_by_user
 local function setup(args)
   if args == nil then
     args = {}
-  end
-
-  local version_issue = version.check_go_version()
-  if version_issue ~= nil then
-    u.notify(version_issue, vim.log.levels.ERROR)
-    return
   end
 
   state.merge_settings(args) -- Merges user settings with default settings

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -4,6 +4,7 @@
 local state = require("gitlab.state")
 local u = require("gitlab.utils")
 local job = require("gitlab.job")
+local version = require("gitlab.version")
 local M = {}
 
 -- Builds the binary if it doesn't exist, and starts the server. If the pre-existing binary has an older
@@ -23,8 +24,8 @@ M.build_and_start = function(callback)
       callback()
       return
     end
-    M.get_version(function(version)
-      if version.plugin_version ~= version.binary_version then
+    M.get_version(function(versions)
+      if versions.plugin_version ~= versions.binary_version then
         M.shutdown(function()
           if M.build(true) then
             M.start(callback)
@@ -116,6 +117,12 @@ M.build = function(override)
     return
   end
 
+  local version_issue = version.check_go_version()
+  if version_issue ~= nil then
+    u.notify(version_issue, vim.log.levels.ERROR)
+    return
+  end
+
   -- If the user did not provide a path, we build it and place it in either the data path, or the
   -- first writable path we find in the runtime.
   local datapath = vim.fn.stdpath("data")
@@ -150,9 +157,9 @@ M.build = function(override)
   local version_output = vim
     .system({ "git", "describe", "--tags", "--always" }, { cwd = state.settings.root_path })
     :wait()
-  local version = version_output.code == 0 and vim.trim(version_output.stdout) or "unknown"
+  local plugin_version = version_output.code == 0 and vim.trim(version_output.stdout) or "unknown"
 
-  local ldflags = string.format("-X main.Version=%s", version)
+  local ldflags = string.format("-X main.Version=%s", plugin_version)
   local res = vim
     .system(
       { "go", "build", "-buildvcs=false", "-ldflags", ldflags, "-o", state.settings.server.binary },

--- a/lua/gitlab/server.lua
+++ b/lua/gitlab/server.lua
@@ -106,20 +106,11 @@ M.build = function(override)
 
   -- If the user provided a path to the server, don't build it.
   if state.settings.server.binary_provided then
-    local binary_exists = vim.loop.fs_stat(state.settings.server.binary)
-    if binary_exists == nil then
-      u.notify(
-        string.format("The user-provided server path (%s) does not exist.", state.settings.server.binary),
-        vim.log.levels.ERROR
-      )
-      return false
-    end
     return
   end
 
   local version_issue = version.check_go_version()
   if version_issue ~= nil then
-    u.notify(version_issue, vim.log.levels.ERROR)
     return
   end
 

--- a/lua/gitlab/version.lua
+++ b/lua/gitlab/version.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.is_go_valid = function()
-  local go_version = io.popen("go version"):read("*a")
+  local go_version = io.popen("go version 2>&1"):read("*a")
   if go_version then
     local major, minor, _ = go_version:match("(%d+)%.(%d+)%.?(%d*)")
     if major and tonumber(major) >= 1 and tonumber(minor) >= 25 then

--- a/lua/gitlab/version.lua
+++ b/lua/gitlab/version.lua
@@ -7,7 +7,7 @@ M.is_go_valid = function()
   end
 
   local go_version = vim.version.parse(go:wait().stdout, { strict = false })
-  return vim.version.ge(go_version, { 1, 25, 0 })
+  return go_version ~= nil and vim.version.ge(go_version, { 1, 25, 0 })
 end
 
 M.check_go_version = function()

--- a/lua/gitlab/version.lua
+++ b/lua/gitlab/version.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local minimum_go_version = "1.25.1"
+
 M.is_go_valid = function()
   local has_go, go = pcall(vim.system, { "go", "version" })
   if not has_go then
@@ -7,13 +9,16 @@ M.is_go_valid = function()
   end
 
   local go_version = vim.version.parse(go:wait().stdout, { strict = false })
-  return go_version ~= nil and vim.version.ge(go_version, { 1, 25, 0 })
+  return go_version ~= nil and vim.version.ge(go_version, minimum_go_version)
 end
 
 M.check_go_version = function()
   local has_version = M.is_go_valid()
   if not has_version then
-    return "Go is not installed, or version is older than 1.25.1. Please reinstall up-to-date Go version: https://go.dev/dl/"
+    return string.format(
+      "Go is not installed, or version is older than %s. Please reinstall up-to-date Go version: https://go.dev/dl/",
+      minimum_go_version
+    )
   end
 end
 

--- a/lua/gitlab/version.lua
+++ b/lua/gitlab/version.lua
@@ -6,13 +6,8 @@ M.is_go_valid = function()
     return false
   end
 
-  local go_version = go:wait().stdout;
-  local major, minor, _ = go_version:match("(%d+)%.(%d+)%.?(%d*)")
-  if major and tonumber(major) >= 1 and tonumber(minor) >= 25 then
-    return true
-  else
-    return false
-  end
+  local go_version = vim.version.parse(go:wait().stdout, { strict = false })
+  return vim.version.ge(go_version, { 1, 25, 0 })
 end
 
 M.check_go_version = function()

--- a/lua/gitlab/version.lua
+++ b/lua/gitlab/version.lua
@@ -1,14 +1,15 @@
 local M = {}
 
 M.is_go_valid = function()
-  local go_version = io.popen("go version 2>&1"):read("*a")
-  if go_version then
-    local major, minor, _ = go_version:match("(%d+)%.(%d+)%.?(%d*)")
-    if major and tonumber(major) >= 1 and tonumber(minor) >= 25 then
-      return true
-    else
-      return false
-    end
+  local has_go, go = pcall(vim.system, {"go", "version"});
+  if not has_go then
+    return false
+  end
+
+  local go_version = go:wait().stdout;
+  local major, minor, _ = go_version:match("(%d+)%.(%d+)%.?(%d*)")
+  if major and tonumber(major) >= 1 and tonumber(minor) >= 25 then
+    return true
   else
     return false
   end

--- a/lua/gitlab/version.lua
+++ b/lua/gitlab/version.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.is_go_valid = function()
-  local has_go, go = pcall(vim.system, {"go", "version"});
+  local has_go, go = pcall(vim.system, { "go", "version" })
   if not has_go then
     return false
   end


### PR DESCRIPTION
I use NixOS and prefer to keep my environment clean. As such, I prebuilt the plugin's server binary using Nix and specified its path in `setup`. However, `setup` forcibly checks Go version and aborts if I don't have it installed, which doesn't make sense because Go is only required to build the server and I already have one. Thus I moved the check to `server.build` function when it actually needs to build the server. I also touched `version.lua` to remove the annoying `go: command not found` message when starting Neovim (I'm not sure if this is a good way to fix it since I'm not a Lua programmer, so I'm open to suggestions).